### PR TITLE
show errors when running tests in wasm

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,10 +8,6 @@ edition = "2021"
 [lib]
 crate-type = ["cdylib"]
 
-[profile.test]
-opt-level = 0
-overflow-checks = false
-
 [profile.release]
 lto = true
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,10 +36,24 @@ impl Scripts {
 #[cfg(test)]
 mod tests {
     use crate::Scripts;
+    use std::io::{self, Write};
     mod nearmock;
+
+    use std::sync::Once;
+
+    static INIT: Once = Once::new();
+
+    pub fn setup() {
+        INIT.call_once(|| {
+            std::panic::set_hook(Box::new(|panic_info| {
+                let _ = writeln!(io::stderr(), "{}", panic_info);
+            }));
+        });
+    }
 
     #[test]
     fn test_run_script() {
+        setup();
         let contract = Scripts::default();
         
         let result = contract.run_script("print('hello');(1+2+3);".to_string());

--- a/test.sh
+++ b/test.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
-RUSTFLAGS='-C link-arg=-s' cargo test --target=wasm32-wasi --no-run
-$HOME/.wasmtime/bin/wasmtime target/wasm32-wasi/debug/deps/*.wasm -- --show-output
+cargo test --target=wasm32-wasi --no-run
+WASMTIME_BACKTRACE_DETAILS=1 $HOME/.wasmtime/bin/wasmtime target/wasm32-wasi/debug/deps/*.wasm -- --show-output


### PR DESCRIPTION
this provides being able to display assertion errors like below. requires that every test sets up the panic hook.

![image](https://user-images.githubusercontent.com/9760441/185473583-2f02a85a-b306-4b06-a9d9-7574d9288035.png)
