### PR TITLE
Support unit testing in wasm32 target with minimum mocked NEAR environment

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1003,6 +1003,7 @@ name = "quickjs-rust-near"
 version = "0.1.0"
 dependencies = [
  "bindgen",
+ "lazy_static",
  "near-sdk",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ lto = true
 
 [dependencies]
 near-sdk = "4.0.0"
+lazy_static = "1.4.0"
 
 [build-dependencies]
 bindgen = "0.60.1"

--- a/src/jslib.rs
+++ b/src/jslib.rs
@@ -1,3 +1,6 @@
+use std::slice;
+use std::ffi::CString;
+
 extern "C" {
     fn create_runtime();
     fn js_eval(filename: i32, script: i32, is_module: i32) -> i32;
@@ -7,9 +10,12 @@ extern "C" {
 
 pub fn run_js(script: String) -> i32 {
     let result: i32;
+    let filename = CString::new("main.js").unwrap();
+    let scriptstring = CString::new(script).unwrap();
+        
     unsafe {
         create_runtime();
-        result = js_eval("main.js".as_ptr() as i32, script.as_ptr() as i32, 0);
+        result = js_eval(filename.as_ptr() as i32, scriptstring.as_ptr() as i32, 0);
     }
     return result;
 }
@@ -29,13 +35,15 @@ pub fn compile_js(script: String) -> Vec<u8> {
         create_runtime();
         let mut out_buf_len: usize = 0;
         let out_buf_len_ptr: *mut usize = &mut out_buf_len;
+        let filename = CString::new("main.js").unwrap();
+        let scriptstring = CString::new(script).unwrap();
         let result_ptr = js_compile_to_bytecode(
-            "main.js".as_ptr() as i32,
-            script.as_ptr() as i32,
+            filename.as_ptr() as i32,
+            scriptstring.as_ptr() as i32,
             out_buf_len_ptr as i32,
             0
         );
-        result = Vec::from_raw_parts(result_ptr as *mut u8, out_buf_len, out_buf_len);
+        result = slice::from_raw_parts(result_ptr as *mut u8, out_buf_len).to_vec();
     }
     return result;
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,12 +1,12 @@
+use near_sdk::borsh::{self, BorshDeserialize, BorshSerialize};
+use near_sdk::{base64, env, near_bindgen};
 use std::collections::HashMap;
-use near_sdk::{env, near_bindgen, base64};
-use near_sdk::borsh::{self, BorshDeserialize,BorshSerialize};
 mod jslib;
 mod wasimock;
 #[near_bindgen]
 #[derive(Default, BorshDeserialize, BorshSerialize)]
 pub struct Scripts {
-    scripts: HashMap<String, Vec<u8>>
+    scripts: HashMap<String, Vec<u8>>,
 }
 
 #[near_bindgen]
@@ -16,11 +16,11 @@ impl Scripts {
     }
 
     pub fn run_bytecode(&self, bytecodebase64: String) -> String {
-        let bytecode:Result<Vec<u8>, base64::DecodeError> = base64::decode(&bytecodebase64);
+        let bytecode: Result<Vec<u8>, base64::DecodeError> = base64::decode(&bytecodebase64);
         return jslib::run_js_bytecode(bytecode.unwrap()).to_string();
     }
 
-    pub fn submit_script(&mut self, script: String) {        
+    pub fn submit_script(&mut self, script: String) {
         let compiled = jslib::compile_js(script);
         env::log_str(&(compiled.len().to_string()));
         let account_id = env::signer_account_id();
@@ -29,13 +29,13 @@ impl Scripts {
 
     pub fn run_script_for_account(&self, account_id: String) -> String {
         let bytecode = self.scripts.get(&account_id).unwrap().to_vec();
-        return jslib::run_js_bytecode(bytecode).to_string();    
+        return jslib::run_js_bytecode(bytecode).to_string();
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::Scripts;
+    use super::*;
     use std::io::{self, Write};
     mod nearmock;
 
@@ -55,8 +55,18 @@ mod tests {
     fn test_run_script() {
         setup();
         let contract = Scripts::default();
-        
+
         let result = contract.run_script("print('hello');(1+2+3);".to_string());
         assert_eq!("6".to_string(), result);
+    }
+
+    #[test]
+    fn test_submit_and_run_stored_script() {
+        setup();
+        let mut contract = Scripts::default();
+
+        contract.submit_script("(function () { return 15+4+3; })()".to_string());
+        let result = contract.run_script_for_account("test.near".to_string());
+        assert_eq!("22".to_string(), result);
     }
 }


### PR DESCRIPTION
Minimum implementation of NEAR env methods to support unit testing from Rust for the wasm32 target (near-sdk-rs testing tools does not support this as also discussed here: https://github.com/near/near-sdk-rs/issues/467 )

Also bugfixes on passing / receiving data to/from the C library ( QuickJS ).