### PR TITLE
chore: ignore Spin installer artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,9 @@ example-contracts.car
 yarn-error.log
 *keypair.json
 package-lock.json
+
+# Artifacts dropped by the Spin install script when run from this directory
+/spin
+/LICENSE
+crt.pem
+spin.sig


### PR DESCRIPTION
## Summary
- The Spin install script extracts `LICENSE`, `crt.pem`, `spin.sig`, and a `spin` binary into the current working directory.
- When run from this repo checkout, those appear as untracked files (and the `LICENSE` can be mistaken for an intentional repo file).
- Ignore them so future installs don't pollute `git status` or risk an accidental commit.

## Test plan
- [x] `git status` is clean after running the Spin installer with these entries in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)