### PR TITLE
Upgrade QuickJS from 2024-01-13 to 2026-06-04

### DIFF
--- a/.devcontainer/install-dependencies.sh
+++ b/.devcontainer/install-dependencies.sh
@@ -15,18 +15,18 @@ rustup target add wasm32-unknown-unknown
 rustup target add wasm32-wasip1
 
 # Install Binaryen
-wget https://github.com/WebAssembly/binaryen/releases/download/version_116/binaryen-version_116-x86_64-linux.tar.gz
-tar -xvzf binaryen-version_116-x86_64-linux.tar.gz 
-echo 'export PATH="$(pwd)/binaryen-version_116/bin:$PATH"' >> ~/.bashrc
+wget https://github.com/WebAssembly/binaryen/releases/download/version_131/binaryen-version_131-x86_64-linux.tar.gz
+tar -xvzf binaryen-version_131-x86_64-linux.tar.gz 
+echo 'export PATH="$(pwd)/binaryen-version_131/bin:$PATH"' >> ~/.bashrc
 
 # Install Wasmtime
 curl https://wasmtime.dev/install.sh -sSf | bash
 echo 'export PATH="$HOME/.wasmtime/bin:$PATH"' >> ~/.bashrc
 
 # Install QuickJS
-wget https://bellard.org/quickjs/quickjs-2024-01-13.tar.xz
-tar -xf quickjs-2024-01-13.tar.xz
-rm quickjs-2024-01-13.tar.xz
+wget https://bellard.org/quickjs/quickjs-2026-06-04.tar.xz
+tar -xf quickjs-2026-06-04.tar.xz
+rm quickjs-2026-06-04.tar.xz
 
 # Install WABT (WebAssembly Binary Toolkit)
 wget https://github.com/WebAssembly/wabt/releases/download/1.0.35/wabt-1.0.35.tar.xz

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,8 +30,8 @@ jobs:
             node_modules
             emsdk
             wabt-1.0.35
-            binaryen-version_116
-            quickjs-2024-01-13
+            binaryen-version_131
+            quickjs-2026-06-04
           key: ${{ runner.os }}-dependencies-${{ hashFiles('**/yarn.lock', '.devcontainer/install-dependencies.sh') }}
 
       - name: Install dependencies
@@ -57,14 +57,14 @@ jobs:
             node_modules
             emsdk
             wabt-1.0.35
-            binaryen-version_116
-            quickjs-2024-01-13
+            binaryen-version_131
+            quickjs-2026-06-04
           key: ${{ runner.os }}-dependencies-${{ hashFiles('**/yarn.lock', '.devcontainer/install-dependencies.sh') }}
 
       - name: Set up paths and Rust
         run: |
           echo "$HOME/.wasmtime/bin" >> $GITHUB_PATH
-          echo "$(pwd)/binaryen-version_116/bin" >> $GITHUB_PATH
+          echo "$(pwd)/binaryen-version_131/bin" >> $GITHUB_PATH
           echo "$(pwd)/wabt-1.0.35/bin" >> $GITHUB_PATH
           rustup target add wasm32-wasip1 
           rustup target add wasm32-unknown-unknown
@@ -100,14 +100,14 @@ jobs:
             node_modules
             emsdk
             wabt-1.0.35
-            binaryen-version_116
-            quickjs-2024-01-13
+            binaryen-version_131
+            quickjs-2026-06-04
           key: ${{ runner.os }}-dependencies-${{ hashFiles('**/yarn.lock', '.devcontainer/install-dependencies.sh') }}
 
       - name: Set up paths and Rust
         run: |
           echo "$HOME/.wasmtime/bin" >> $GITHUB_PATH
-          echo "$(pwd)/binaryen-version_116/bin" >> $GITHUB_PATH
+          echo "$(pwd)/binaryen-version_131/bin" >> $GITHUB_PATH
           echo "$(pwd)/wabt-1.0.35/bin" >> $GITHUB_PATH
           rustup target add wasm32-wasip1 
           rustup target add wasm32-unknown-unknown
@@ -143,14 +143,14 @@ jobs:
             node_modules
             emsdk
             wabt-1.0.35
-            binaryen-version_116
-            quickjs-2024-01-13
+            binaryen-version_131
+            quickjs-2026-06-04
           key: ${{ runner.os }}-dependencies-${{ hashFiles('**/yarn.lock', '.devcontainer/install-dependencies.sh') }}
 
       - name: Set up paths and Rust
         run: |
           echo "$HOME/.wasmtime/bin" >> $GITHUB_PATH
-          echo "$(pwd)/binaryen-version_116/bin" >> $GITHUB_PATH
+          echo "$(pwd)/binaryen-version_131/bin" >> $GITHUB_PATH
           echo "$(pwd)/wabt-1.0.35/bin" >> $GITHUB_PATH
           rustup target add wasm32-wasip1 
           rustup target add wasm32-unknown-unknown
@@ -186,14 +186,14 @@ jobs:
             node_modules
             emsdk
             wabt-1.0.35
-            binaryen-version_116
-            quickjs-2024-01-13
+            binaryen-version_131
+            quickjs-2026-06-04
           key: ${{ runner.os }}-dependencies-${{ hashFiles('**/yarn.lock', '.devcontainer/install-dependencies.sh') }}
 
       - name: Set up paths and Rust
         run: |
           echo "$HOME/.wasmtime/bin" >> $GITHUB_PATH
-          echo "$(pwd)/binaryen-version_116/bin" >> $GITHUB_PATH
+          echo "$(pwd)/binaryen-version_131/bin" >> $GITHUB_PATH
           echo "$(pwd)/wabt-1.0.35/bin" >> $GITHUB_PATH
           rustup target add wasm32-wasip1 
           rustup target add wasm32-unknown-unknown
@@ -226,14 +226,14 @@ jobs:
             node_modules
             emsdk
             wabt-1.0.35
-            binaryen-version_116
-            quickjs-2024-01-13
+            binaryen-version_131
+            quickjs-2026-06-04
           key: ${{ runner.os }}-dependencies-${{ hashFiles('**/yarn.lock', '.devcontainer/install-dependencies.sh') }}
 
       - name: Set up paths and Rust
         run: |
           echo "$HOME/.wasmtime/bin" >> $GITHUB_PATH
-          echo "$(pwd)/binaryen-version_116/bin" >> $GITHUB_PATH
+          echo "$(pwd)/binaryen-version_131/bin" >> $GITHUB_PATH
           echo "$(pwd)/wabt-1.0.35/bin" >> $GITHUB_PATH
           echo "$(pwd)/bin" >> $GITHUB_PATH
           rustup target add wasm32-wasip1
@@ -282,14 +282,14 @@ jobs:
             node_modules
             emsdk
             wabt-1.0.35
-            binaryen-version_116
-            quickjs-2024-01-13
+            binaryen-version_131
+            quickjs-2026-06-04
           key: ${{ runner.os }}-dependencies-${{ hashFiles('**/yarn.lock', '.devcontainer/install-dependencies.sh') }}
 
       - name: Set up paths and Rust
         run: |
           echo "$HOME/.wasmtime/bin" >> $GITHUB_PATH
-          echo "$(pwd)/binaryen-version_116/bin" >> $GITHUB_PATH
+          echo "$(pwd)/binaryen-version_131/bin" >> $GITHUB_PATH
           echo "$(pwd)/wabt-1.0.35/bin" >> $GITHUB_PATH
           rustup target add wasm32-wasip1 
           rustup target add wasm32-unknown-unknown
@@ -323,14 +323,14 @@ jobs:
             node_modules
             emsdk
             wabt-1.0.35
-            binaryen-version_116
-            quickjs-2024-01-13
+            binaryen-version_131
+            quickjs-2026-06-04
           key: ${{ runner.os }}-dependencies-${{ hashFiles('**/yarn.lock', '.devcontainer/install-dependencies.sh') }}
 
       - name: Set up paths and Rust
         run: |
           echo "$HOME/.wasmtime/bin" >> $GITHUB_PATH
-          echo "$(pwd)/binaryen-version_116/bin" >> $GITHUB_PATH
+          echo "$(pwd)/binaryen-version_131/bin" >> $GITHUB_PATH
           echo "$(pwd)/wabt-1.0.35/bin" >> $GITHUB_PATH
           rustup target add wasm32-wasip1 
           rustup target add wasm32-unknown-unknown
@@ -362,14 +362,14 @@ jobs:
             node_modules
             emsdk
             wabt-1.0.35
-            binaryen-version_116
-            quickjs-2024-01-13
+            binaryen-version_131
+            quickjs-2026-06-04
           key: ${{ runner.os }}-dependencies-${{ hashFiles('**/yarn.lock', '.devcontainer/install-dependencies.sh') }}
 
       - name: Set up paths
         run: |
           echo "$HOME/.wasmtime/bin" >> $GITHUB_PATH
-          echo "$(pwd)/binaryen-version_116/bin" >> $GITHUB_PATH
+          echo "$(pwd)/binaryen-version_131/bin" >> $GITHUB_PATH
           echo "$(pwd)/wabt-1.0.35/bin" >> $GITHUB_PATH
 
       - name: Run QuickJSLib Tests
@@ -400,14 +400,14 @@ jobs:
             node_modules
             emsdk
             wabt-1.0.35
-            binaryen-version_116
-            quickjs-2024-01-13
+            binaryen-version_131
+            quickjs-2026-06-04
           key: ${{ runner.os }}-dependencies-${{ hashFiles('**/yarn.lock', '.devcontainer/install-dependencies.sh') }}
 
       - name: Set up paths and Rust
         run: |
           echo "$HOME/.wasmtime/bin" >> $GITHUB_PATH
-          echo "$(pwd)/binaryen-version_116/bin" >> $GITHUB_PATH
+          echo "$(pwd)/binaryen-version_131/bin" >> $GITHUB_PATH
           echo "$(pwd)/wabt-1.0.35/bin" >> $GITHUB_PATH
           rustup target add wasm32-wasip1 
           rustup target add wasm32-unknown-unknown

--- a/.github/workflows/release-example-contracts.yml
+++ b/.github/workflows/release-example-contracts.yml
@@ -16,6 +16,7 @@ jobs:
 
       - name: Restore Cache
         uses: actions/cache@v4
+        id: cache-dependencies
         with:
           path: |
             ~/.wasmtime
@@ -27,6 +28,11 @@ jobs:
             binaryen-version_131
             quickjs-2026-06-04
           key: ${{ runner.os }}-dependencies-${{ hashFiles('**/yarn.lock', '.devcontainer/install-dependencies.sh') }}
+
+      - name: Install dependencies
+        if: steps.cache-dependencies.outputs.cache-hit != 'true'
+        run: |
+          ./.devcontainer/install-dependencies.sh
 
       - name: Set up paths and Rust
         run: |

--- a/.github/workflows/release-example-contracts.yml
+++ b/.github/workflows/release-example-contracts.yml
@@ -24,14 +24,14 @@ jobs:
             node_modules
             emsdk
             wabt-1.0.35
-            binaryen-version_116
-            quickjs-2024-01-13
+            binaryen-version_131
+            quickjs-2026-06-04
           key: ${{ runner.os }}-dependencies-${{ hashFiles('**/yarn.lock', '.devcontainer/install-dependencies.sh') }}
 
       - name: Set up paths and Rust
         run: |
           echo "$HOME/.wasmtime/bin" >> $GITHUB_PATH
-          echo "$(pwd)/binaryen-version_116/bin" >> $GITHUB_PATH
+          echo "$(pwd)/binaryen-version_131/bin" >> $GITHUB_PATH
           echo "$(pwd)/wabt-1.0.35/bin" >> $GITHUB_PATH
           rustup target add wasm32-wasip1 
           rustup target add wasm32-unknown-unknown

--- a/build.rs
+++ b/build.rs
@@ -30,7 +30,7 @@ fn main() {
     );
     println!(
         "cargo:rustc-link-search=native={}",
-        Path::new(&dir).join("quickjs-2024-01-13").display()
+        Path::new(&dir).join("quickjs-2026-06-04").display()
     );
     println!("cargo:rustc-link-lib=static=quickjs");
     println!("cargo:rustc-link-lib=static=jseval");

--- a/build.sh
+++ b/build.sh
@@ -4,7 +4,7 @@ mkdir -p out
 # Build for WebAssembly target
 cargo build --target=wasm32-unknown-unknown --release
 # Remove unneeded WebAssembly exports
-wasm-metadce -f meta-dce.json target/wasm32-unknown-unknown/release/quickjs_rust_near.wasm -o out/main.wasm
+wasm-metadce --enable-sign-ext --enable-bulk-memory --enable-nontrapping-float-to-int --enable-mutable-globals -f meta-dce.json target/wasm32-unknown-unknown/release/quickjs_rust_near.wasm -o out/main.wasm
 # Optimize the Wasm binary
-wasm-opt --converge -Oz --signext-lowering out/main.wasm -o out/main.wasm
+wasm-opt --enable-sign-ext --enable-bulk-memory --enable-nontrapping-float-to-int --enable-mutable-globals --signext-lowering --llvm-nontrapping-fptoint-lowering --llvm-memory-copy-fill-lowering --converge -Oz out/main.wasm -o out/main.wasm
 echo "The webassembly binary can be found in out/main.wasm"

--- a/buildanddeploy.sh
+++ b/buildanddeploy.sh
@@ -4,6 +4,6 @@ mkdir -p out
 # Build for WebAssembly target
 cargo build --target=wasm32-unknown-unknown --release
 # Remove unneeded WebAssembly exports
-wasm-metadce -f meta-dce.json target/wasm32-unknown-unknown/release/quickjs_rust_near.wasm -o out/main.wasm
+wasm-metadce --enable-sign-ext --enable-bulk-memory --enable-nontrapping-float-to-int --enable-mutable-globals -f meta-dce.json target/wasm32-unknown-unknown/release/quickjs_rust_near.wasm -o out/main.wasm
 # Optimize the Wasm binary
-wasm-opt --converge -Oz --signext-lowering out/main.wasm -o out/main.wasm
+wasm-opt --enable-sign-ext --enable-bulk-memory --enable-nontrapping-float-to-int --enable-mutable-globals --signext-lowering --llvm-nontrapping-fptoint-lowering --llvm-memory-copy-fill-lowering --converge -Oz out/main.wasm -o out/main.wasm

--- a/examples/fungibletoken/build.sh
+++ b/examples/fungibletoken/build.sh
@@ -4,7 +4,7 @@ set -e
 cargo build --target=wasm32-unknown-unknown --release
 # Remove unneeded WebAssembly exports
 mkdir -p out
-wasm-metadce -f meta-dce.json ../../target/wasm32-unknown-unknown/release/quickjs_rust_near_fungible_token.wasm -o out/fungible_token.wasm
+wasm-metadce --enable-sign-ext --enable-bulk-memory --enable-nontrapping-float-to-int --enable-mutable-globals -f meta-dce.json ../../target/wasm32-unknown-unknown/release/quickjs_rust_near_fungible_token.wasm -o out/fungible_token.wasm
 # Optimize the Wasm binary
-wasm-opt --converge -Oz --signext-lowering out/fungible_token.wasm -o out/fungible_token.wasm
+wasm-opt --enable-sign-ext --enable-bulk-memory --enable-nontrapping-float-to-int --enable-mutable-globals --signext-lowering --llvm-nontrapping-fptoint-lowering --llvm-memory-copy-fill-lowering --converge -Oz out/fungible_token.wasm -o out/fungible_token.wasm
 echo "you can find the contract wasm file in out/fungible_token.wasm"

--- a/examples/minimumweb4/build.sh
+++ b/examples/minimumweb4/build.sh
@@ -4,6 +4,6 @@ set -e
 RUSTFLAGS='-C link-arg=-s' cargo build --target=wasm32-unknown-unknown --release
 mkdir -p out
 # Remove unneeded WebAssembly exports
-wasm-metadce -f meta-dce.json ../../target/wasm32-unknown-unknown/release/quickjs_rust_near_minimum_web4.wasm -o out/minimum_web4.wasm
+wasm-metadce --enable-sign-ext --enable-bulk-memory --enable-nontrapping-float-to-int --enable-mutable-globals -f meta-dce.json ../../target/wasm32-unknown-unknown/release/quickjs_rust_near_minimum_web4.wasm -o out/minimum_web4.wasm
 # Optimize the Wasm binary
-wasm-opt -Oz --signext-lowering out/minimum_web4.wasm -o out/minimum_web4.wasm
+wasm-opt --enable-sign-ext --enable-bulk-memory --enable-nontrapping-float-to-int --enable-mutable-globals --signext-lowering --llvm-nontrapping-fptoint-lowering --llvm-memory-copy-fill-lowering -Oz out/minimum_web4.wasm -o out/minimum_web4.wasm

--- a/examples/nft/build.sh
+++ b/examples/nft/build.sh
@@ -4,7 +4,7 @@ set -e
 cargo build --target=wasm32-unknown-unknown --release
 # Remove unneeded WebAssembly exports
 mkdir -p out
-wasm-metadce -f meta-dce.json ../../target/wasm32-unknown-unknown/release/quickjs_rust_near_nft.wasm -o out/nft.wasm
+wasm-metadce --enable-sign-ext --enable-bulk-memory --enable-nontrapping-float-to-int --enable-mutable-globals -f meta-dce.json ../../target/wasm32-unknown-unknown/release/quickjs_rust_near_nft.wasm -o out/nft.wasm
 # Optimize the Wasm binary
-wasm-opt --converge -Oz --signext-lowering out/nft.wasm -o out/nft.wasm
+wasm-opt --enable-sign-ext --enable-bulk-memory --enable-nontrapping-float-to-int --enable-mutable-globals --signext-lowering --llvm-nontrapping-fptoint-lowering --llvm-memory-copy-fill-lowering --converge -Oz out/nft.wasm -o out/nft.wasm
 echo "you can find the contract wasm file in out/nft.wasm"

--- a/examples/purejs/build.sh
+++ b/examples/purejs/build.sh
@@ -8,6 +8,6 @@ wasm2wat $WASM_FILENAME > purejs.wat
 OBJDUMP_DATA_SECTION=`wasm-objdump -h $WASM_FILENAME | grep "Data start"`
 node ./manipulatepurejswat.js "$OBJDUMP_DATA_SECTION"
 wat2wasm purejs.wat
-wasm-metadce -f meta-dce.json purejs.wasm -o purejs.wasm
+wasm-metadce --enable-sign-ext --enable-bulk-memory --enable-nontrapping-float-to-int --enable-mutable-globals -f meta-dce.json purejs.wasm -o purejs.wasm
 # Optimize the Wasm binary
-wasm-opt -Oz --signext-lowering purejs.wasm -o purejs.wasm
+wasm-opt --enable-sign-ext --enable-bulk-memory --enable-nontrapping-float-to-int --enable-mutable-globals --signext-lowering --llvm-nontrapping-fptoint-lowering --llvm-memory-copy-fill-lowering -Oz purejs.wasm -o purejs.wasm

--- a/quickjslib/build.sh
+++ b/quickjslib/build.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 source ../emsdk/emsdk_env.sh
-QUICKJS_ROOT=../quickjs-2024-01-13
+QUICKJS_ROOT=../quickjs-2026-06-04
 export CC=clang
 (cd $QUICKJS_ROOT && make CC=emcc AR=emar libquickjs.a)
 emcc -Oz -I$QUICKJS_ROOT libjseval.c -c

--- a/src/jslib.rs
+++ b/src/jslib.rs
@@ -239,8 +239,8 @@ unsafe fn setup_quickjs() {
             // as a properly tagged float64 per quickjs.h __JS_NewFloat64:
             //   JSValue = double_bits - (JS_FLOAT64_TAG_ADDEND << 32)
             //   JS_FLOAT64_TAG_ADDEND = 0x7ff80000 - JS_TAG_FIRST + 1
-            //                         = 0x7ff80000 - (-11) + 1 = 0x7ff8000c
-            const FLOAT64_TAG_ADDEND_SHIFTED: u64 = 0x7ff8000c_00000000;
+            //                         = 0x7ff80000 - (-9) + 1 = 0x7ff8000a
+            const FLOAT64_TAG_ADDEND_SHIFTED: u64 = 0x7ff8000a_00000000;
             let bits = (env::block_timestamp_ms() as f64).to_bits();
             bits.wrapping_sub(FLOAT64_TAG_ADDEND_SHIFTED) as i64
         },


### PR DESCRIPTION
## Summary

Upgrades the embedded QuickJS engine from the 2024-01-13 release to the latest upstream release, [2026-06-04](https://bellard.org/quickjs/) (which upstream reports as ~42% faster on bench-v8 than the previous release).

### Changes

- **Version bumps** in `.devcontainer/install-dependencies.sh` (download URL), `quickjslib/build.sh` (`QUICKJS_ROOT`), `build.rs` (link search path), and CI workflow cache paths.
- **NaN-boxing fix in `src/jslib.rs`**: upstream removed the BigFloat/BigDecimal tags (2025-04-26 release), changing `JS_TAG_FIRST` from -11 to -9. The hardcoded `JS_FLOAT64_TAG_ADDEND` used to encode `block_timestamp_ms` as a tagged float64 is updated from `0x7ff8000c` to `0x7ff8000a`.
- **Binaryen upgrade version_116 → version_131** plus explicit `--enable-*` feature flags and new lowering passes (`--llvm-nontrapping-fptoint-lowering`, `--llvm-memory-copy-fill-lowering`) in all `build.sh` scripts. Newer Emscripten releases emit post-MVP wasm instructions (bulk memory, nontrapping float-to-int) by default; these passes lower them back to MVP-compatible code for the NEAR VM. With the pinned emcc 3.1.74 the extra passes are no-ops.

### Notes

- Upstream removed the bignum extensions (`CONFIG_BIGNUM`, libbf) — BigInt is now built-in with a compact implementation. No changes needed on our side; the Makefile's `libquickjs.a` target still works with `CC=emcc`.
- New JS features available to contracts: WeakRef/FinalizationRegistry, JSON modules, `Float16Array`, `Promise.try()`, resizable ArrayBuffers, Uint8Array base64/hex methods, and more.
- ⚠️ **The QuickJS bytecode format changed between releases.** Any contract JS precompiled to bytecode with the old engine must be recompiled and redeployed after this upgrade.

### Testing

- ✅ All unit test suites pass locally in wasmtime (main crate 18, testenv 1, nft 16, minimumweb4 2, fungibletoken 8).
- ✅ `build.sh` and `examples/fungibletoken/build.sh` produce valid MVP-compatible wasm (verified no `memory.copy`/`memory.fill`/`trunc_sat`/sign-ext instructions remain after wasm-opt).
- ⏳ e2e tests could not run on this machine (near-sandbox binary in node_modules is a Linux aarch64 build from the devcontainer) — relying on CI for e2e coverage, hence draft.

🤖 Generated with [Claude Code](https://claude.com/claude-code)