### PR TITLE
Fix trusted publishing: drop registry-url from setup-node

### DIFF
--- a/.github/workflows/release-quickjs-wasm.yml
+++ b/.github/workflows/release-quickjs-wasm.yml
@@ -24,7 +24,9 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '22'
-          registry-url: 'https://registry.npmjs.org'
+          # No registry-url here: it would write an .npmrc with an
+          # _authToken placeholder, which makes npm use (broken) token auth
+          # instead of the OIDC exchange for trusted publishing.
 
       - name: Install emsdk
         uses: mymindstorm/setup-emsdk@v14


### PR DESCRIPTION
setup-node's `registry-url` writes an `.npmrc` with a `NODE_AUTH_TOKEN` placeholder (`XXXXX-...`), so `npm publish` on the v0.0.2 tag attempted token auth and got E404 instead of doing the OIDC exchange for trusted publishing. Removing `registry-url` lets npm ≥ 11.5.1 detect the trusted publisher and authenticate via OIDC.

After merge, the `quickjs-wasm-v0.0.2` tag will be moved to the fixed commit to retry the publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)