### PR TITLE
Add diagnostics to npm publish step (OIDC troubleshooting)

### DIFF
--- a/.github/workflows/release-quickjs-wasm.yml
+++ b/.github/workflows/release-quickjs-wasm.yml
@@ -55,4 +55,6 @@ jobs:
         # (node 22 ships npm 10.x). Provenance is attested automatically.
         run: |
           npm install -g npm@latest
-          cd quickjslib && npm publish
+          npm --version
+          echo "OIDC token request URL available: ${ACTIONS_ID_TOKEN_REQUEST_URL:+yes}"
+          cd quickjslib && npm publish --loglevel http


### PR DESCRIPTION
Publish on the retagged v0.0.2 still failed, now with ENEEDAUTH — npm did not complete an OIDC exchange. This surfaces npm version, OIDC env availability, and HTTP-level logs to pinpoint whether the exchange is attempted and why it fails.

🤖 Generated with [Claude Code](https://claude.com/claude-code)