### PR TITLE
Remove OIDC troubleshooting diagnostics from publish step

### DIFF
--- a/.github/workflows/release-quickjs-wasm.yml
+++ b/.github/workflows/release-quickjs-wasm.yml
@@ -55,6 +55,4 @@ jobs:
         # (node 22 ships npm 10.x). Provenance is attested automatically.
         run: |
           npm install -g npm@latest
-          npm --version
-          echo "OIDC token request URL available: ${ACTIONS_ID_TOKEN_REQUEST_URL:+yes}"
-          cd quickjslib && npm publish --loglevel http
+          cd quickjslib && npm publish


### PR DESCRIPTION
quickjs-wasm@0.0.2 published successfully via trusted publishing, so the temporary diagnostics (npm version echo, OIDC env check, http-level logging) can go.

🤖 Generated with [Claude Code](https://claude.com/claude-code)