### PR TITLE
README: document quickjs-wasm as a standalone npm package

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,28 @@ See the entire build process in [build.rs](./build.rs).
 
 In the Rust part, there are contract implementations exposing functions for submitting JavaScript code. Both in the internal bytecode format of QuickJS, and pure JS source code.
 
+# quickjs-wasm: standalone JavaScript sandbox on npm
+
+The QuickJS WebAssembly wrapper in [quickjslib](./quickjslib/) is also published on its own as [`quickjs-wasm`](https://www.npmjs.com/package/quickjs-wasm), for running untrusted JavaScript in an isolated sandbox in the browser or in Node - without any NEAR smart contract involved. The guest has no access to the host page or process: no `fetch`, no DOM, no filesystem, only the host functions you explicitly expose.
+
+```bash
+npm install quickjs-wasm
+```
+
+```javascript
+import { createQuickJS } from "quickjs-wasm";
+
+const quickjs = await createQuickJS();
+quickjs.setMemoryLimit(16 * 1024 * 1024);
+
+// third parameter is a timeout in milliseconds, so runaway code cannot hang the host
+const result = quickjs.evalSource("40 + 2;", "<evalsource>", 1000);
+```
+
+See the [package README](./quickjslib/README.md) for the full API: compiling to bytecode, calling into modules, the async host function contract (`env.callHostAsync`), and the limits API. The [WebAssembly Music](https://github.com/petersalomonsen/javascriptmusic) project uses it to sandbox user submitted song scripts.
+
+Releases are built and published from [this workflow](./.github/workflows/release-quickjs-wasm.yml) by pushing a `quickjs-wasm-v*` tag. The wasm build is reproducible ( pinned QuickJS and emsdk versions, verified byte-identical in CI ), and packages are published with [npm provenance](https://docs.npmjs.com/generating-provenance-statements) through trusted publishing.
+
 # Unit tests running in WebAssembly
 
 While it's common and more straightforward for NEAR smart contracts and many other Rust WebAssembly projects, to have their unit tests compiled to the native platform, this project runs the unit test in a WebAssembly runtime. The reason for this is because of the static libraries compiled from C, which are already targeting Wasm. One limitation when running tests inside the Wasm runtime is that you cannot catch panics, and so testing the error messages has to be done in the end-2-end tests


### PR DESCRIPTION
The root README mentioned [quickjslib](./quickjslib/) only as a C library linked into the Rust contract, so a reader had no way to discover that it is also published as [`quickjs-wasm`](https://www.npmjs.com/package/quickjs-wasm) and usable standalone in the browser or Node.

Adds a section after "Architecture / structure" with: install, a minimal example (memory limit + eval timeout), a link to the package README for the full API (bytecode, modules, `env.callHostAsync`, limits), the WebAssembly Music usage as a reference consumer, and a note on the reproducible build + trusted-publishing release flow.

The example was verified verbatim against the published `quickjs-wasm@0.0.2` from the registry — bare specifier import resolves and returns 42.

🤖 Generated with [Claude Code](https://claude.com/claude-code)