### PR TITLE
readme instance lifetime

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,28 @@ See the entire build process in [build.rs](./build.rs).
 
 In the Rust part, there are contract implementations exposing functions for submitting JavaScript code. Both in the internal bytecode format of QuickJS, and pure JS source code.
 
+# quickjs-wasm: standalone JavaScript sandbox on npm
+
+The QuickJS WebAssembly wrapper in [quickjslib](./quickjslib/) is also published on its own as [`quickjs-wasm`](https://www.npmjs.com/package/quickjs-wasm), for running untrusted JavaScript in an isolated sandbox in the browser or in Node - without any NEAR smart contract involved. The guest has no access to the host page or process: no `fetch`, no DOM, no filesystem, only the host functions you explicitly expose.
+
+```bash
+npm install quickjs-wasm
+```
+
+```javascript
+import { createQuickJS } from "quickjs-wasm";
+
+const quickjs = await createQuickJS();
+quickjs.setMemoryLimit(16 * 1024 * 1024);
+
+// third parameter is a timeout in milliseconds, so runaway code cannot hang the host
+const result = quickjs.evalSource("40 + 2;", "<evalsource>", 1000);
+```
+
+See the [package README](./quickjslib/README.md) for the full API: compiling to bytecode, calling into modules, the async host function contract (`env.callHostAsync`), and the limits API. The [WebAssembly Music](https://github.com/petersalomonsen/javascriptmusic) project uses it to sandbox user submitted song scripts.
+
+Releases are built and published from [this workflow](./.github/workflows/release-quickjs-wasm.yml) by pushing a `quickjs-wasm-v*` tag. The wasm build is reproducible ( pinned QuickJS and emsdk versions, verified byte-identical in CI ), and packages are published with [npm provenance](https://docs.npmjs.com/generating-provenance-statements) through trusted publishing.
+
 # Unit tests running in WebAssembly
 
 While it's common and more straightforward for NEAR smart contracts and many other Rust WebAssembly projects, to have their unit tests compiled to the native platform, this project runs the unit test in a WebAssembly runtime. The reason for this is because of the static libraries compiled from C, which are already targeting Wasm. One limitation when running tests inside the Wasm runtime is that you cannot catch panics, and so testing the error messages has to be done in the end-2-end tests

--- a/quickjslib/README.md
+++ b/quickjslib/README.md
@@ -19,6 +19,18 @@ npm install quickjs-wasm
 - Access JavaScript objects and properties
 - Protect the host against runaway guest code with memory limits and eval timeouts
 
+## Intended use: one sandbox per execution
+
+This library is built for **short-lived, single-use JavaScript environments**: create an instance, run one untrusted script, throw the instance away.
+
+There is deliberately no disposal API. QuickJS's own garbage collector still runs inside the guest, but the host bindings do not clean up: the C strings allocated for every `evalSource`/`getObjectPropertyValue` call are never freed, and QuickJS values handed back to the host keep their references for the lifetime of the instance. Memory is reclaimed when the whole wasm instance is dropped and garbage collected by the host — not before. Keeping one instance alive across many evaluations in a long-running process will grow memory.
+
+Creating a fresh instance per execution is also the stronger isolation property: no state carries over between untrusted scripts — no polluted prototypes, no globals stashed by a previous run, nothing observable from one script to the next.
+
+Both users of this library work that way. In a NEAR smart contract the protocol instantiates the contract wasm per call and discards it afterwards. In [WebAssembly Music](https://github.com/petersalomonsen/javascriptmusic) `createQuickJS()` is called once per song compilation.
+
+If you need a long-lived JS environment shared by many scripts over time, use [quickjs-emscripten](https://github.com/justjake/quickjs-emscripten) instead — it manages value lifetimes explicitly.
+
 ## The async model
 
 Guest `await` suspends at the JavaScript level *inside* QuickJS: when guest code calls an async host function, QuickJS parks the guest execution as a pending promise and the wasm call returns to the host. There is no Emscripten asyncify (or any stack switching) anywhere — the wasm stack fully unwinds on every host call. The host later resumes the guest by resolving the promise via `promise_callback`, which also runs QuickJS's pending-job loop. This is why `waitForPendingAsyncInvocations()` must be awaited before reading a promise result: it drains the host-side async invocations that resume the guest.


### PR DESCRIPTION
The package README documented the API but never stated the constraint that shapes how it should be used: instances are single-use.

There is no disposal API — the C strings allocated per `evalSource`/`getObjectPropertyValue` are never freed and QuickJS values handed to the host keep their references — so memory is only reclaimed when the whole wasm instance is dropped. Both consumers already work this way (NEAR instantiates the contract wasm per call; `runSongInSandbox` calls `createQuickJS()` per song compile), but a new user had no way to know that was required rather than incidental.

Also frames the fresh-instance-per-run pattern as the stronger isolation property (no state carryover between untrusted scripts), and points users who need a long-lived shared environment at quickjs-emscripten instead — drop that last line if you'd rather not link a competitor.

`npm test` — 22/22 pass (README examples are executed by `readme-eval.test.js`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)