### PR TITLE
Compile the wasm module once and share it between instances

### DIFF
--- a/quickjslib/README.md
+++ b/quickjslib/README.md
@@ -27,6 +27,8 @@ There is deliberately no disposal API. QuickJS's own garbage collector still run
 
 Creating a fresh instance per execution is also the stronger isolation property: no state carries over between untrusted scripts — no polluted prototypes, no globals stashed by a previous run, nothing observable from one script to the next.
 
+Instances are cheap. The wasm module is fetched and compiled once per page or process and then shared, so every `createQuickJS()` after the first only allocates a fresh linear memory — sharing a compiled `WebAssembly.Module` shares no state.
+
 Both users of this library work that way. In a NEAR smart contract the protocol instantiates the contract wasm per call and discards it afterwards. In [WebAssembly Music](https://github.com/petersalomonsen/javascriptmusic) `createQuickJS()` is called once per song compilation.
 
 If you need a long-lived JS environment shared by many scripts over time, use [quickjs-emscripten](https://github.com/justjake/quickjs-emscripten) instead — it manages value lifetimes explicitly.

--- a/quickjslib/js/quickjs.js
+++ b/quickjslib/js/quickjs.js
@@ -30,6 +30,31 @@ const float64scratch = new DataView(new ArrayBuffer(8));
 const textEncoder = new TextEncoder();
 const textDecoder = new TextDecoder();
 
+/* The compiled module is fetched and compiled once and then shared by every
+   instance. Each instance still gets its own fresh linear memory - sharing a
+   WebAssembly.Module shares no state whatsoever - so the one-sandbox-per-
+   execution model keeps its isolation while paying the ~900KB compile only
+   on the first createQuickJS() call. */
+let compiledModulePromise = null;
+
+function getCompiledModule() {
+  if (!compiledModulePromise) {
+    compiledModulePromise = (async () => {
+      const url = new URL("../jseval.wasm", import.meta.url);
+      const wasm =
+        url.protocol === "file:"
+          ? await (await import("fs/promises")).readFile(url)
+          : await fetch(url).then((r) => r.arrayBuffer());
+      return await WebAssembly.compile(wasm);
+    })().catch((e) => {
+      /* Do not cache a failed load, so a later call can retry. */
+      compiledModulePromise = null;
+      throw e;
+    });
+  }
+  return compiledModulePromise;
+}
+
 class QuickJS {
   constructor() {
     this.hostFunctions = {};
@@ -50,44 +75,33 @@ class QuickJS {
         this.stderrlines.push(data.join(" "));
         console.error(...data);
       };
-      const url = new URL("../jseval.wasm", import.meta.url);
-      const wasm =
-        url.protocol === "file:"
-          ? await (await import("fs/promises")).readFile(url)
-          : await fetch(url).then((r) => r.arrayBuffer());
-
-      const mod = (
-        await WebAssembly.instantiate(wasm, {
-          wasi_snapshot_preview1: this.wasi,
-          env: {
-            js_host_time_ms: () => Date.now(),
-            js_call_host_async: async (params, resolving_func) => {
-              this.pendingAsyncInvocations.push(
-                new Promise(async (resolvePendingInvocation) => {
-                  try {
-                    const hostFunctionName = this.getObjectPropertyValue(
-                      params,
-                      "function_name",
-                    );
-                    if (this.hostFunctions[hostFunctionName]) {
-                      const result =
-                        await this.hostFunctions[hostFunctionName](params);
-                      this.wasmInstance.promise_callback(
-                        resolving_func,
-                        result,
-                      );
-                    } else {
-                      this.wasmInstance.promise_callback(resolving_func, null);
-                    }
-                  } finally {
-                    resolvePendingInvocation();
+      const mod = await WebAssembly.instantiate(await getCompiledModule(), {
+        wasi_snapshot_preview1: this.wasi,
+        env: {
+          js_host_time_ms: () => Date.now(),
+          js_call_host_async: async (params, resolving_func) => {
+            this.pendingAsyncInvocations.push(
+              new Promise(async (resolvePendingInvocation) => {
+                try {
+                  const hostFunctionName = this.getObjectPropertyValue(
+                    params,
+                    "function_name",
+                  );
+                  if (this.hostFunctions[hostFunctionName]) {
+                    const result =
+                      await this.hostFunctions[hostFunctionName](params);
+                    this.wasmInstance.promise_callback(resolving_func, result);
+                  } else {
+                    this.wasmInstance.promise_callback(resolving_func, null);
                   }
-                }),
-              );
-            },
+                } finally {
+                  resolvePendingInvocation();
+                }
+              }),
+            );
           },
-        })
-      ).instance;
+        },
+      });
       this.wasi.init(mod);
       this.wasmInstance = mod.exports;
       this.wasmInstance.init();

--- a/quickjslib/js/quickjs.test.js
+++ b/quickjslib/js/quickjs.test.js
@@ -7,6 +7,16 @@ test("evaluate js", async () => {
   equal(quickjs.evalSource("42;"), 42);
 });
 
+test("instances share no state", async () => {
+  const first = await createQuickJS();
+  const second = await createQuickJS();
+
+  first.evalSource("globalThis.secret = 42; Object.prototype.polluted = 1;");
+  equal(first.evalSource("globalThis.secret;"), 42);
+  equal(second.evalSource("typeof globalThis.secret;"), "undefined");
+  equal(second.evalSource("typeof ({}).polluted;"), "undefined");
+});
+
 test("evaluate js returning a float", async () => {
   const quickjs = await createQuickJS();
   equal(quickjs.evalSource("0.5;"), 0.5);
@@ -49,10 +59,7 @@ test("terminate an infinite loop via eval timeout", async () => {
 test("memory limit stops allocation bomb without killing the host", async () => {
   const quickjs = await createQuickJS();
   quickjs.setMemoryLimit(16 * 1024 * 1024);
-  throws(
-    () => quickjs.evalSource("new Array(1e9).fill(0);"),
-    /out of memory/,
-  );
+  throws(() => quickjs.evalSource("new Array(1e9).fill(0);"), /out of memory/);
   equal(quickjs.evalSource("1 + 1;"), 2);
 });
 


### PR DESCRIPTION
`createQuickJS()` passed the raw bytes to `WebAssembly.instantiate` on every call, so each instance re-fetched and re-compiled the ~880KB module. Since both consumers create a fresh instance per execution (that is [the documented usage model](https://github.com/petersalomonsen/quickjs-rust-near/blob/main/quickjslib/README.md#intended-use-one-sandbox-per-execution)), that cost was paid on every song compile / contract run.

The module is now compiled once and cached at module scope. Each instance still gets its own fresh linear memory — sharing a compiled `WebAssembly.Module` shares no state — so the isolation property is unchanged. A failed load is not cached, so a later call can retry.

## Measured

20 sequential `createQuickJS()` calls in node, after a warm-up call so neither variant pays the initial file read:

| | per instance |
|---|---|
| before | ~1.6ms |
| after | ~0.35ms |

~4.4× faster. In the browser the win is larger, since it also avoids re-fetching the wasm from the CDN on every run.

## Verification

- `npm test` — 23/23 pass, including a new test asserting two instances share no state (neither globals nor `Object.prototype` pollution), which is the property this change could plausibly break.
- Ran javascriptmusic's sandbox suite against this build by dropping it into its installed package — 5/5 pass, including the runaway-song interrupt test (the real per-song-compile path).

Also documents in the package README that instances are cheap, which supports the one-sandbox-per-execution guidance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)