### PR TITLE
Free host-owned wasm allocations at the call boundary

### DIFF
--- a/quickjslib/README.md
+++ b/quickjslib/README.md
@@ -179,7 +179,7 @@ Untrusted guest code can attempt to hang the host (`while(true){}`) or exhaust m
 const quickjs = await createQuickJS();
 
 // Cap how much memory the QuickJS runtime may allocate (bytes)
-quickjs.setMemoryLimit(16 * 1024 * 1024);
+quickjs.setMemoryLimit(12 * 1024 * 1024);
 
 // An allocation bomb now fails inside the sandbox instead of killing the host
 try {
@@ -205,6 +205,8 @@ if (result !== 42) throw new Error("Expected 42, got " + result);
 `callModFunction(mod, functionName, timeoutMs)` and `evalByteCode(bytecode, timeoutMs)` accept the same timeout parameter. The timeout is enforced by a wall-clock check in QuickJS's interrupt handler, so it also covers pending jobs executed at the end of the call. It does *not* cover guest code resumed later by an async host-function response; `requestInterrupt()` can be called from a host function to terminate the guest when it next resumes.
 
 When an eval fails — an exception thrown by guest code, an interrupted eval, or an exceeded memory limit — the wrapper throws an `Error` whose message is the QuickJS exception message.
+
+The wasm linear memory is a fixed ~16.5MB and cannot grow, so that is the hard ceiling whatever limit you set. Running into it is still reported as a catchable `out of memory` exception and the instance stays usable, but keeping the limit below the ceiling makes the bound explicit and leaves room for the strings and buffers the host bindings allocate on the guest's behalf.
 
 ## API Reference
 

--- a/quickjslib/js/quickjs.js
+++ b/quickjslib/js/quickjs.js
@@ -112,7 +112,10 @@ class QuickJS {
   allocateString(str) {
     const instance = this.wasmInstance;
     const encoded = textEncoder.encode(str);
-    const straddr = instance.malloc(encoded.length + 1);
+    const straddr = this.checkAllocation(
+      instance.malloc(encoded.length + 1),
+      encoded.length + 1,
+    );
     const buf = new Uint8Array(
       instance.memory.buffer,
       straddr,
@@ -134,6 +137,37 @@ class QuickJS {
     const memorybuf = new Uint8Array(this.wasmInstance.memory.buffer);
     const end = memorybuf.indexOf(0, ptr);
     return textDecoder.decode(memorybuf.subarray(ptr, end));
+  }
+
+  /**
+   * Allocates C strings for the duration of `fn` and frees them afterwards.
+   * QuickJS copies what it is handed here - sources are consumed during
+   * compilation, filenames and property names become interned atoms - so
+   * nothing needs to outlive the call.
+   */
+  withStrings(strings, fn) {
+    const ptrs = strings.map((str) => this.allocateString(str));
+    try {
+      return fn(...ptrs);
+    } finally {
+      for (const ptr of ptrs) {
+        this.wasmInstance.free(ptr);
+      }
+    }
+  }
+
+  /**
+   * Allocates a buffer for the duration of `fn` and frees it afterwards.
+   * Safe for bytecode: JS_ReadObject duplicates the buffer unless it is
+   * given JS_READ_OBJ_ROM_DATA, which this library never does.
+   */
+  withBuf(binarydata, fn) {
+    const { addr, len } = this.allocateBuf(binarydata);
+    try {
+      return fn(addr, len);
+    } finally {
+      this.wasmInstance.free(addr);
+    }
   }
 
   /**
@@ -170,21 +204,22 @@ class QuickJS {
   evalSource(src, modulefilename = "<evalsource>", timeoutMs = 0) {
     const instance = this.wasmInstance;
     return this.withEvalDeadline(timeoutMs, () =>
-      this.convertReturnValue(
-        instance.eval_js_source(
-          this.allocateString(modulefilename),
-          this.allocateString(src),
-          modulefilename != "<evalsource>",
+      this.withStrings([modulefilename, src], (filenameptr, srcptr) =>
+        this.convertReturnValue(
+          instance.eval_js_source(
+            filenameptr,
+            srcptr,
+            modulefilename != "<evalsource>",
+          ),
         ),
       ),
     );
   }
 
   getObjectPropertyValue(jsval, propertyname) {
-    return this.convertReturnValue(
-      this.wasmInstance.get_js_obj_property(
-        jsval,
-        this.allocateString(propertyname),
+    return this.withStrings([propertyname], (nameptr) =>
+      this.convertReturnValue(
+        this.wasmInstance.get_js_obj_property(jsval, nameptr),
       ),
     );
   }
@@ -216,8 +251,14 @@ class QuickJS {
       case JS_TAG_BOOL:
         return BigInt.asIntN(32, jsval) !== 0n;
       case JS_TAG_STRING:
-      case JS_TAG_STRING_ROPE:
-        return this.ptrToString(this.wasmInstance.get_js_string(jsval));
+      case JS_TAG_STRING_ROPE: {
+        const strptr = this.wasmInstance.get_js_string(jsval);
+        try {
+          return this.ptrToString(strptr);
+        } finally {
+          this.wasmInstance.free_js_string(strptr);
+        }
+      }
       case JS_TAG_OBJECT:
         return jsval;
       case JS_TAG_NULL:
@@ -232,9 +273,26 @@ class QuickJS {
     }
   }
 
+  /**
+   * The wasm linear memory is a fixed size and cannot grow, so malloc
+   * returns 0 once it is exhausted. Writing at that address would silently
+   * corrupt the low end of the heap, so fail loudly instead.
+   */
+  checkAllocation(addr, size) {
+    if (addr === 0) {
+      throw new Error(
+        `QuickJS sandbox out of memory: could not allocate ${size} bytes`,
+      );
+    }
+    return addr;
+  }
+
   allocateBuf(binarydata) {
     const instance = this.wasmInstance;
-    const bufaddr = instance.malloc(binarydata.length);
+    const bufaddr = this.checkAllocation(
+      instance.malloc(binarydata.length),
+      binarydata.length,
+    );
     const buf = new Uint8Array(
       instance.memory.buffer,
       bufaddr,
@@ -247,50 +305,56 @@ class QuickJS {
   }
 
   loadByteCode(bytecode) {
-    const { addr, len } = this.allocateBuf(bytecode);
-    return this.wasmInstance.load_js_bytecode(addr, len);
+    return this.withBuf(bytecode, (addr, len) =>
+      this.wasmInstance.load_js_bytecode(addr, len),
+    );
   }
 
   callModFunction(mod, functionname, timeoutMs = 0) {
     return this.withEvalDeadline(timeoutMs, () =>
-      this.convertReturnValue(
-        this.wasmInstance.call_js_function(
-          mod,
-          this.allocateString(functionname),
+      this.withStrings([functionname], (nameptr) =>
+        this.convertReturnValue(
+          this.wasmInstance.call_js_function(mod, nameptr),
         ),
       ),
     );
   }
 
   evalByteCode(bytecode, timeoutMs = 0) {
-    const { addr, len } = this.allocateBuf(bytecode);
     return this.withEvalDeadline(timeoutMs, () =>
-      this.convertReturnValue(this.wasmInstance.eval_js_bytecode(addr, len)),
+      this.withBuf(bytecode, (addr, len) =>
+        this.convertReturnValue(this.wasmInstance.eval_js_bytecode(addr, len)),
+      ),
     );
   }
 
   compileToByteCode(src, modulefilename = "<evalsource>") {
     const instance = this.wasmInstance;
-    const compiledbytecodebuflenptr = instance.malloc(4);
-    const compiledbytecodeaddr = instance.compile_to_bytecode(
-      this.allocateString(modulefilename),
-      this.allocateString(src),
-      compiledbytecodebuflenptr,
-      modulefilename != "<evalsource>",
-    );
-
-    const compiledbytecodebuflen = new Uint32Array(
-      instance.memory.buffer,
-      compiledbytecodebuflenptr,
-      4,
-    )[0];
-    console.log("len", compiledbytecodebuflen);
-
-    return new Uint8Array(
-      instance.memory.buffer,
-      compiledbytecodeaddr,
-      compiledbytecodebuflen,
-    );
+    const buflenptr = instance.malloc(4);
+    try {
+      return this.withStrings([modulefilename, src], (filenameptr, srcptr) => {
+        const bytecodeaddr = instance.compile_to_bytecode(
+          filenameptr,
+          srcptr,
+          buflenptr,
+          modulefilename != "<evalsource>",
+        );
+        const buflen = new Uint32Array(instance.memory.buffer, buflenptr, 1)[0];
+        try {
+          /* Copy out rather than returning a view: any later allocation that
+             grows the wasm memory detaches views into it. */
+          return new Uint8Array(
+            instance.memory.buffer,
+            bytecodeaddr,
+            buflen,
+          ).slice();
+        } finally {
+          instance.free_js_bytecode(bytecodeaddr);
+        }
+      });
+    } finally {
+      instance.free(buflenptr);
+    }
   }
 }
 

--- a/quickjslib/js/quickjs.test.js
+++ b/quickjslib/js/quickjs.test.js
@@ -63,6 +63,28 @@ test("memory limit stops allocation bomb without killing the host", async () => 
   equal(quickjs.evalSource("1 + 1;"), 2);
 });
 
+test("gradual allocation hits the limit as a catchable exception", async () => {
+  const quickjs = await createQuickJS();
+  quickjs.setMemoryLimit(12 * 1024 * 1024);
+  throws(
+    () => quickjs.evalSource("const a = []; for (;;) a.push(new Array(1000));"),
+    /out of memory/,
+  );
+  equal(quickjs.evalSource("1 + 1;"), 2);
+});
+
+// Every crossing of the host boundary allocates inside the wasm heap, which
+// is a fixed 16.5MB and cannot grow. Without freeing those allocations this
+// exhausts the heap and traps partway through.
+test("repeated large evaluations do not exhaust the heap", async () => {
+  const quickjs = await createQuickJS();
+  const source = `/*${"x".repeat(100 * 1024)}*/ 42;`;
+  for (let n = 0; n < 150; n++) {
+    equal(quickjs.evalSource(source), 42);
+    equal(quickjs.evalByteCode(quickjs.compileToByteCode(source)), 42);
+  }
+});
+
 test("compile and run bytecode", async () => {
   const quickjs = await createQuickJS();
   const bytecode = await quickjs.compileToByteCode("42;");

--- a/quickjslib/wasmlib.c
+++ b/quickjslib/wasmlib.c
@@ -67,6 +67,40 @@ void __secs_to_zone(long long secs, int *p_offset, int *p_dst, long *p_time, lon
     *p_time_dst = secs;
 }
 
+/* Prints the pending exception for the host to pick up from stdout. The
+   message has to be formatted with an allocation, which is exactly what
+   fails when the runtime is out of memory, so fall back to a fixed string
+   rather than printing "(null)". */
+static void print_exception(JSContext *ctx)
+{
+    JSValue exception = JS_GetException(ctx);
+    const char *str;
+
+    /* QuickJS throws JS_NULL when it cannot even allocate the error object
+       ("out of memory: throw JS_NULL to avoid recursing" in quickjs.c), and
+       formatting a message needs an allocation too - so under memory
+       exhaustion both degrade to a message the host cannot use. Report the
+       same text QuickJS uses when it does manage to build the error. */
+    if (JS_IsNull(exception))
+    {
+        printf("InternalError: out of memory\n");
+        JS_FreeValue(ctx, exception);
+        return;
+    }
+
+    str = JS_ToCString(ctx, exception);
+    if (str)
+    {
+        printf("%s\n", str);
+        JS_FreeCString(ctx, str);
+    }
+    else
+    {
+        printf("InternalError: out of memory\n");
+    }
+    JS_FreeValue(ctx, exception);
+}
+
 /* Unlike js_eval in libjseval.c (which returns the int-truncated value for
    the NEAR contract ABI), this returns the full JSValue so floats, strings
    and exceptions reach the host bindings. */
@@ -81,7 +115,7 @@ uint64_t EMSCRIPTEN_KEEPALIVE eval_js_source(char *filename, char *source, int m
 
     if (JS_IsException(val) || JS_IsError(ctx, val))
     {
-        printf("%s\n", JS_ToCString(ctx, JS_GetException(ctx)));
+        print_exception(ctx);
     }
     js_std_loop_no_os(ctx);
     return val;
@@ -115,6 +149,22 @@ uint64_t EMSCRIPTEN_KEEPALIVE get_js_obj_property(uint64_t obj, const char *name
 const char* EMSCRIPTEN_KEEPALIVE get_js_string(uint64_t val)
 {
     return js_get_string(val);
+}
+
+/* Releases a string obtained from get_js_string. JS_ToCString allocates a
+   copy that the caller owns, so without this every string returned to the
+   host grows the QuickJS heap for the lifetime of the instance. */
+void EMSCRIPTEN_KEEPALIVE free_js_string(const char *str)
+{
+    JS_FreeCString(get_js_context(), str);
+}
+
+/* Releases a buffer obtained from compile_to_bytecode. JS_WriteObject
+   allocates it with the QuickJS allocator, so it needs js_free rather than
+   the libc free exported for host allocations. */
+void EMSCRIPTEN_KEEPALIVE free_js_bytecode(uint8_t *buf)
+{
+    js_free(get_js_context(), buf);
 }
 
 const JSValue EMSCRIPTEN_KEEPALIVE new_js_string(const char *str)


### PR DESCRIPTION
Follow-up to the discussion on [the one-sandbox-per-execution model](https://github.com/petersalomonsen/quickjs-rust-near/blob/main/quickjslib/README.md#intended-use-one-sandbox-per-execution). "Leaks are bounded by one execution" was only true because both consumers make very few boundary crossings per run — the allocations actually scale with *crossings*, not with executions.

## What leaked

Every call across the boundary allocated in the wasm heap and never released it:

- the C strings for sources, filenames and property names (`allocateString`, every `evalSource` / `getObjectPropertyValue` / `callModFunction` / `compileToByteCode`)
- the copy `JS_ToCString` makes for **every string returned to the host**
- the bytecode buffers on both sides of compile/load — the host copy and the `JS_WriteObject` result (~56KB per song compile)
- the 4-byte length pointer in `compileToByteCode`

The wasm memory is `initial=259 max=259` pages — a fixed 16.5MB that **cannot grow**. So this is not just untidy: 150 iterations of a 100KB eval exhausts it, `malloc` then returns 0, and the bindings write their payload to address 0 and corrupt the heap until it traps with `RuntimeError: memory access out of bounds`.

## Why it needs no ownership model

QuickJS copies everything it is handed at these call sites — sources are consumed during compilation, filenames and property names become interned atoms, and `JS_ReadObject` duplicates the buffer unless given `JS_READ_OBJ_ROM_DATA` (which this library never passes). So each allocation can be freed the moment the call returns. `withStrings`/`withBuf` scopes do that, and two new exports (`free_js_string`, `free_js_bytecode`) release the two allocations the wasm side owns.

JSValues handed back to the host are still retained for the instance lifetime — that is the part that genuinely needs handles, and it stays out of scope by design.

## Also fixed

- **Allocation failure is loud.** `malloc` returning 0 previously meant writing at address 0; it now throws a clear host-side error.
- **Out-of-memory reporting.** QuickJS deliberately throws `JS_NULL` when it cannot allocate the error object (`"out of memory: throw JS_NULL to avoid recursing"`, quickjs.c:7648), and formatting a message needs an allocation too — so OOM previously surfaced as `Error: null`. Both paths now report `InternalError: out of memory`. Fixed in `wasmlib.c` only; the contract-shared `libjseval.c` is untouched.
- **`compileToByteCode` returns a copy** instead of a live view into wasm memory, which any later heap-growing allocation would detach. It also no longer logs `len` on every call — say the word if you want that back.

## Verification

| workload (fixed 16.5MB heap) | before | after |
|---|---|---|
| 200 × 100KB `evalSource` | traps: memory access out of bounds | stable, 0KB growth |
| 200 × 100KB compile + eval | traps | stable, 0KB growth |

- `npm test` — 25/25, including new tests for sustained large evaluations and for gradual allocation hitting the limit as a catchable exception with the instance still usable afterwards.
- Contract unit tests — 18/18 (`libjseval.c` untouched, but `build.rs` runs this build).
- javascriptmusic sandbox suite against this build — 5/5, including the runaway-song interrupt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)