### PR TITLE
README: state the single-use model in the quickjs-wasm section

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,12 +40,15 @@ npm install quickjs-wasm
 ```javascript
 import { createQuickJS } from "quickjs-wasm";
 
+// one sandbox per untrusted script - run it, take the result, drop the instance
 const quickjs = await createQuickJS();
-quickjs.setMemoryLimit(16 * 1024 * 1024);
+quickjs.setMemoryLimit(12 * 1024 * 1024);
 
 // third parameter is a timeout in milliseconds, so runaway code cannot hang the host
 const result = quickjs.evalSource("40 + 2;", "<evalsource>", 1000);
 ```
+
+It is built for short-lived, single-use JavaScript environments rather than as a long-lived engine shared by many scripts: there is no disposal API, and memory is reclaimed when the instance is dropped. That is also what gives each untrusted script a guaranteed clean slate, and it is how both users of the library work - NEAR instantiates the contract wasm per call, and WebAssembly Music creates a sandbox per song compilation. See [Intended use: one sandbox per execution](./quickjslib/README.md#intended-use-one-sandbox-per-execution).
 
 See the [package README](./quickjslib/README.md) for the full API: compiling to bytecode, calling into modules, the async host function contract (`env.callHostAsync`), and the limits API. The [WebAssembly Music](https://github.com/petersalomonsen/javascriptmusic) project uses it to sandbox user submitted song scripts.
 


### PR DESCRIPTION
Follow-up to #59 and #60: the root README section landed before the package README gained its "one sandbox per execution" framing, so it advertised the package without the constraint that shapes how it should be used.

Adds a short paragraph — single-use by design, no disposal API, which is also what guarantees each untrusted script a clean slate — with a link to the [package README section](./quickjslib/README.md#intended-use-one-sandbox-per-execution), plus a comment in the snippet making the pattern visible at a glance.

Also lowers the example memory limit from 16MB to 12MB: the wasm linear memory is fixed at ~16.5MB (`initial=259 max=259` pages), so a 16MB limit sits at the ceiling and never really binds. 12MB makes the example meaningful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)