### PR TITLE
quickjs-wasm 0.0.3

### DIFF
--- a/quickjslib/package.json
+++ b/quickjslib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "quickjs-wasm",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Execute javascript in a secure WebAssembly sandbox",
   "main": "js/quickjs.js",
   "type": "module",


### PR DESCRIPTION
Version bump for release. Everything in it is already merged and green on main:

- **#61** — the wasm module is compiled once per process and shared, so instance creation is ~4.4× faster (~1.6ms → ~0.35ms) while each instance keeps its own fresh memory.
- **#62** — host-owned wasm allocations are freed at the call boundary. Before this, sustained work in a *single* execution exhausted the fixed 16.5MB heap and trapped with `memory access out of bounds`. Also: allocation failure throws instead of writing to address 0, and out-of-memory reports `InternalError: out of memory` instead of `Error: null`.
- **#60 / #63** — documents the one-sandbox-per-execution model and the heap ceiling.

No API changes, so this is drop-in for 0.0.2 consumers.

Merging this and pushing the `quickjs-wasm-v0.0.3` tag publishes via trusted publishing. javascriptmusic's pin gets bumped afterwards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)