### PR TITLE
Release string values, allow releasing handles, fail loudly on compile

### DIFF
--- a/quickjslib/README.md
+++ b/quickjslib/README.md
@@ -23,7 +23,7 @@ npm install quickjs-wasm
 
 This library is built for **short-lived, single-use JavaScript environments**: create an instance, run one untrusted script, throw the instance away.
 
-There is deliberately no disposal API. QuickJS's own garbage collector still runs inside the guest, but the host bindings do not clean up: the C strings allocated for every `evalSource`/`getObjectPropertyValue` call are never freed, and QuickJS values handed back to the host keep their references for the lifetime of the instance. Memory is reclaimed when the whole wasm instance is dropped and garbage collected by the host — not before. Keeping one instance alive across many evaluations in a long-running process will grow memory.
+Values that are converted to host values — numbers, booleans, strings, `null` — are released as soon as they cross the boundary, as are the buffers and C strings each call allocates, so an instance can serve many evaluations without growing. What an instance does not reclaim on its own is object handles: they are returned to you as opaque `bigint`s and stay alive until you call `freeValue(handle)` or the instance is dropped. Whatever you do not release is reclaimed when the whole wasm instance is dropped and garbage collected by the host.
 
 Creating a fresh instance per execution is also the stronger isolation property: no state carries over between untrusted scripts — no polluted prototypes, no globals stashed by a previous run, nothing observable from one script to the next.
 
@@ -234,6 +234,7 @@ The wasm linear memory is a fixed ~16.5MB and cannot grow, so that is the hard c
 
 - `getObjectPropertyValue(object, propertyName)`: Gets a property value from a JavaScript object
 - `allocateJSstring(string)`: Creates a JavaScript string in the QuickJS environment
+- `freeValue(handle)`: Releases an object handle returned by the sandbox (converted values are released automatically)
 
 ### Host Function Integration
 
@@ -242,6 +243,18 @@ The wasm linear memory is a fixed ~16.5MB and cannot grow, so that is the hard c
 ### Value conversion
 
 Return values from the sandbox are converted to host values: integers, floats, booleans, strings (UTF-8 safe), `null` and `undefined` map to their host equivalents; objects (including promises and module handles) are returned as opaque `bigint` handles for use with `getObjectPropertyValue`/`getPromiseResult`/`callModFunction`.
+
+Converted values are released automatically. Handles are not — they are yours until you call `freeValue(handle)`, since only you know when you have finished reading from one. For the one-script-per-instance model you can ignore this entirely; it matters when a single run produces many handles:
+
+```javascript
+const quickjs = await createQuickJS();
+const handle = quickjs.evalSource("({ answer: 42 });");
+const answer = quickjs.getObjectPropertyValue(handle, "answer");
+if (answer !== 42) throw new Error("Expected 42, got " + answer);
+quickjs.freeValue(handle);
+```
+
+A failed compile throws rather than returning empty bytecode, so a source too large to compile is reported at `compileToByteCode` instead of surfacing later as a call on a broken module.
 
 ## Building from source
 

--- a/quickjslib/js/quickjs.js
+++ b/quickjslib/js/quickjs.js
@@ -257,6 +257,11 @@ class QuickJS {
           return this.ptrToString(strptr);
         } finally {
           this.wasmInstance.free_js_string(strptr);
+          /* The host owns this reference and has just copied the whole
+             string out, so nothing needs it any more. Object handles below
+             are different: they are handed to the caller, who releases them
+             with freeValue(). */
+          this.wasmInstance.free_js_value(jsval);
         }
       }
       case JS_TAG_OBJECT:
@@ -270,6 +275,19 @@ class QuickJS {
           this.stdoutlines[this.stdoutlines.length - 1] ??
             "Exception in QuickJS",
         );
+    }
+  }
+
+  /**
+   * Releases an object handle returned by evalSource/callModFunction/
+   * getPromiseResult/getObjectPropertyValue. Values converted to host
+   * values (numbers, strings, booleans, null) are released automatically;
+   * object handles are owned by the caller, because the caller is the only
+   * one who knows when it has finished reading from them.
+   */
+  freeValue(handle) {
+    if (typeof handle === "bigint") {
+      this.wasmInstance.free_js_value(handle);
     }
   }
 
@@ -305,6 +323,9 @@ class QuickJS {
   }
 
   loadByteCode(bytecode) {
+    if (!bytecode || bytecode.length === 0) {
+      throw new Error("Cannot load empty bytecode");
+    }
     return this.withBuf(bytecode, (addr, len) =>
       this.wasmInstance.load_js_bytecode(addr, len),
     );
@@ -340,6 +361,18 @@ class QuickJS {
           modulefilename != "<evalsource>",
         );
         const buflen = new Uint32Array(instance.memory.buffer, buflenptr, 1)[0];
+        /* A compile that fails - a syntax error, or a source large enough
+           that compiling it exhausts the heap - returns an empty buffer.
+           Without this the caller gets a zero-length "bytecode" that fails
+           much later, naming a guest function instead of the compile. */
+        if (bytecodeaddr === 0 || buflen === 0) {
+          throw new Error(
+            `Failed to compile ${modulefilename}: ${
+              this.stdoutlines[this.stdoutlines.length - 1] ??
+              "no bytecode produced"
+            }`,
+          );
+        }
         try {
           /* Copy out rather than returning a view: any later allocation that
              grows the wasm memory detaches views into it. */

--- a/quickjslib/js/quickjs.test.js
+++ b/quickjslib/js/quickjs.test.js
@@ -85,6 +85,42 @@ test("repeated large evaluations do not exhaust the heap", async () => {
   }
 });
 
+// Strings are fully copied out to the host, so the underlying JSValue has no
+// remaining reader. Retaining them meant a few tens of thousands of string
+// returns exhausted the heap.
+test("returned strings do not accumulate in the guest heap", async () => {
+  const quickjs = await createQuickJS();
+  for (let n = 0; n < 60000; n++) {
+    equal(
+      quickjs.evalSource(`"${"x".repeat(500)}${n}";`).length,
+      500 + `${n}`.length,
+    );
+  }
+});
+
+test("object handles can be released with freeValue", async () => {
+  const quickjs = await createQuickJS();
+  for (let n = 0; n < 300000; n++) {
+    const handle = quickjs.evalSource(`({a:${n}});`);
+    equal(quickjs.getObjectPropertyValue(handle, "a"), n);
+    quickjs.freeValue(handle);
+  }
+});
+
+// A compile that runs out of heap returns an empty buffer rather than
+// raising, which used to surface two calls later as "not a function".
+test("a compile that produces no bytecode throws", async () => {
+  const quickjs = await createQuickJS();
+  let src = "";
+  for (let i = 0; i < 20000; i++)
+    src += `export function f${i}() { return ${i}; }\n`;
+  throws(
+    () => quickjs.compileToByteCode(src, "generated.js"),
+    /Failed to compile generated.js/,
+  );
+  throws(() => quickjs.loadByteCode(new Uint8Array(0)), /empty bytecode/);
+});
+
 test("compile and run bytecode", async () => {
   const quickjs = await createQuickJS();
   const bytecode = await quickjs.compileToByteCode("42;");

--- a/quickjslib/wasmlib.c
+++ b/quickjslib/wasmlib.c
@@ -159,6 +159,15 @@ void EMSCRIPTEN_KEEPALIVE free_js_string(const char *str)
     JS_FreeCString(get_js_context(), str);
 }
 
+/* Releases a JSValue the host received from one of the calls above. Those
+   all return a new reference, so a value the host has finished with - a
+   string it has already copied out, or an object handle it is done with -
+   has to be released or it stays alive for the lifetime of the instance. */
+void EMSCRIPTEN_KEEPALIVE free_js_value(uint64_t val)
+{
+    JS_FreeValue(get_js_context(), (JSValue)val);
+}
+
 /* Releases a buffer obtained from compile_to_bytecode. JS_WriteObject
    allocates it with the QuickJS allocator, so it needs js_free rather than
    the libc free exported for host allocations. */


### PR DESCRIPTION
Acting on review feedback for #62. Both points were right, and I reproduced both before fixing them — the reported figures match exactly (objects died at 229,631; strings at ~30k).

## The leak had moved down a level

#62 freed the C buffer behind each returned string but never released the `JSValue`. Numbers, booleans and null are immediates so they were always clean, but strings and objects were still retained:

| workload | before | after |
|---|---|---|
| distinct 500-char string returns | dies at 30,672 | 60,000+ clean |
| `({a:n})` handles, released with `freeValue` | dies at 229,631 | 300,000+ clean |

A string is **fully copied out** to the host and has no remaining reader, so its reference is released with the C buffer — no ownership model needed, and the "no cleanup required" property becomes true by construction rather than true-if-you-don't-return-too-many-strings.

Object handles stay owned by the caller, since only the caller knows when it has finished reading from one — but there was previously no way to release one at all. Adds `freeValue(handle)` and the `free_js_value` export behind it.

## Silent compile failure

A compile producing no bytecode returned an empty buffer without raising; `loadByteCode` accepted it, returned a garbage handle, and the failure surfaced two calls later as `TypeError: not a function`, naming a guest function instead of the compile that actually failed. There is a **window** where this bites:

| generated source | before |
|---|---|
| 198KB | compiles fine |
| 818KB | **silently empty** → garbage handle → misleading error two calls later |
| 1658KB | threw correctly (the `checkAllocation` guard from #62) |

`compileToByteCode` now throws with the QuickJS exception message, and `loadByteCode` rejects empty bytecode. This matters for WebAssembly Music, where generated JS grows with sequence length and would otherwise cross the ceiling and name the wrong thing.

## Verification

- 29/29 package tests. The three new tests were confirmed to **fail without the fix** (heap exhaustion at ~30k strings; no throw on the empty compile), so they are not vacuous.
- Contract unit tests 18/18.
- javascriptmusic sandbox suite on current master against this build — 5/5.
- README corrected: the lifetime section previously said all values handed to the host are retained, which is no longer true.

🤖 Generated with [Claude Code](https://claude.com/claude-code)