### PR TITLE
quickjs-wasm 0.0.4

### DIFF
--- a/quickjslib/package.json
+++ b/quickjslib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "quickjs-wasm",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "Execute javascript in a secure WebAssembly sandbox",
   "main": "js/quickjs.js",
   "type": "module",


### PR DESCRIPTION
Version bump for release. The content is #65, already merged and green on main:

- **String returns no longer accumulate.** The `JSValue` behind a returned string is released along with its C buffer — the string is fully copied out, so nothing can still read it. Previously ~30k string returns exhausted the fixed heap.
- **`freeValue(handle)`** lets callers release object handles, which stay caller-owned because only the caller knows when it has finished reading from one.
- **Failed compiles throw.** A compile producing no bytecode used to return an empty buffer that surfaced two calls later as `TypeError: not a function`; sources roughly 800KB–1.6MB hit that window. `loadByteCode` also rejects empty bytecode now.

No breaking API changes — `freeValue` is additive, and the new throws replace failures that previously surfaced later and less clearly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)