### PR TITLE
quickjs-wasm 0.0.5: TypeScript declarations, retention policy, changelog

### DIFF
--- a/quickjslib/CHANGELOG.md
+++ b/quickjslib/CHANGELOG.md
@@ -1,0 +1,70 @@
+# Changelog
+
+Versions below 0.1.0 do not guarantee a stable API, but behaviour changes are
+called out explicitly here. A change to the return contract of a public
+function warrants a minor bump rather than a patch, so consumers pinning exact
+versions can tell an upgrade apart from a fix.
+
+## 0.0.4
+
+**Behaviour change — two functions now throw where they previously returned:**
+
+| function | before | now |
+| --- | --- | --- |
+| `compileToByteCode` | returned an empty buffer when the compile failed | throws `Failed to compile <file>: <QuickJS exception>` |
+| `loadByteCode` | accepted empty bytecode and returned an unusable handle | throws `Cannot load empty bytecode` |
+
+A caller that inspected the returned length instead of catching would take an
+uncaught throw on upgrade. No consumer in this repo or in WebAssembly Music did
+so, but this should have been a minor bump.
+
+The motivating consumer is
+[`examples/aiproxy/web/openai/sandbox.js`](../examples/aiproxy/web/openai/sandbox.js),
+which interpolates untrusted script text straight into `compileToByteCode` with
+no `try`/`catch` — an unbounded, possibly invalid source. (The pull request that
+made this change cited WebAssembly Music instead, which was wrong: its song
+source never reaches `compileToByteCode`. It is passed into the sandbox as a
+string and compiled inside the guest, so `compileToByteCode` only ever sees the
+fixed-size guest bundle.)
+
+Also in this release:
+
+- Strings returned to the host release their `JSValue` along with the C buffer.
+  A string is fully copied out, so nothing can still read it — this makes "no
+  cleanup required" true by construction rather than true until a single run
+  returns tens of thousands of strings.
+- `freeValue(handle)` releases an object handle early. One-shot users never
+  need it; see the retention policy in the README.
+
+## 0.0.3
+
+- Frees the wasm-heap allocations made on every crossing of the host boundary:
+  sources, filenames, property names, and the bytecode buffers on both sides of
+  compile/load. The heap is a fixed ~16.5MB that cannot grow, so sustained work
+  in a single run previously exhausted it and trapped.
+- Allocation failure throws a clear error instead of writing to address 0.
+- Out-of-memory is reported as `InternalError: out of memory` rather than
+  `null`. QuickJS throws `JS_NULL` when it cannot allocate the error object,
+  and formatting a message needs an allocation too, so both paths degraded.
+- `compileToByteCode` returns a copy instead of a view into wasm memory, which
+  a later heap-growing allocation would detach.
+- The wasm module is compiled once per page or process and shared between
+  instances, making `createQuickJS()` roughly 4x cheaper. Each instance still
+  gets its own fresh linear memory.
+
+## 0.0.2
+
+- Correct value conversion for QuickJS 2026-06-04: float64 (NaN-boxed) returns,
+  signed integers, booleans, rope strings, and guest exceptions surfaced as host
+  errors. Previously a non-integer number came back as `undefined`.
+- UTF-8 safe strings in both directions; `ptrToString` no longer copies the
+  whole wasm memory per call.
+- Sandbox limits: `setMemoryLimit(bytes)`, a `timeoutMs` parameter on
+  `evalSource`/`evalByteCode`/`callModFunction` backed by a wall-clock interrupt
+  handler, and `requestInterrupt()`.
+- Reproducible build against pinned QuickJS 2026-06-04 and emsdk 3.1.74,
+  verified byte-identical in CI, published with npm provenance.
+
+## 0.0.1
+
+Initial release.

--- a/quickjslib/CHANGELOG.md
+++ b/quickjslib/CHANGELOG.md
@@ -5,6 +5,26 @@ called out explicitly here. A change to the return contract of a public
 function warrants a minor bump rather than a patch, so consumers pinning exact
 versions can tell an upgrade apart from a fix.
 
+## 0.0.5
+
+No behaviour changes — types and documentation only.
+
+- Ships TypeScript declarations (`js/quickjs.d.ts`). The distinction that
+  matters most in this API is now visible at the call site: converted values
+  (`number | string | boolean | null | undefined`) versus `JSHandle`, an opaque
+  reference to something still living inside the sandbox.
+- Ships this changelog.
+- The README states an explicit retention policy: a retention only observable
+  by keeping one instance alive across many scripts is not a bug, while
+  anything scaling with a single run's work is. Without a rule like that,
+  leak reports have no stopping point — an audit of the C entry points finds
+  bounded per-instance references in `js_call_function`, `js_load_bytecode`,
+  `js_std_loop_no_os` and `promise_callback`, none of which one-shot use can
+  observe.
+- `freeValue` is documented as an escape hatch rather than part of the model.
+  It was introduced in 0.0.4 with wording that read as a caller obligation,
+  which contradicts the one-sandbox-per-execution design.
+
 ## 0.0.4
 
 **Behaviour change — two functions now throw where they previously returned:**

--- a/quickjslib/README.md
+++ b/quickjslib/README.md
@@ -23,7 +23,7 @@ npm install quickjs-wasm
 
 This library is built for **short-lived, single-use JavaScript environments**: create an instance, run one untrusted script, throw the instance away.
 
-Values that are converted to host values — numbers, booleans, strings, `null` — are released as soon as they cross the boundary, as are the buffers and C strings each call allocates, so an instance can serve many evaluations without growing. What an instance does not reclaim on its own is object handles: they are returned to you as opaque `bigint`s and stay alive until you call `freeValue(handle)` or the instance is dropped. Whatever you do not release is reclaimed when the whole wasm instance is dropped and garbage collected by the host.
+**You are never required to release anything.** Dropping the instance reclaims all of it, and there is no disposal API you have to remember. Values converted to host values — numbers, booleans, strings, `null` — are released as they cross the boundary, along with the buffers and C strings each call allocates, so an instance can serve many evaluations without growing. Object handles are the one thing the library cannot release for you, because only you know when you have finished reading from one; they stay alive until the instance is dropped. `freeValue(handle)` exists for the rare run that produces handles in the hundreds of thousands, which would otherwise exhaust the instance's own heap before it finishes — it is an escape hatch, not an obligation.
 
 Creating a fresh instance per execution is also the stronger isolation property: no state carries over between untrusted scripts — no polluted prototypes, no globals stashed by a previous run, nothing observable from one script to the next.
 
@@ -234,7 +234,7 @@ The wasm linear memory is a fixed ~16.5MB and cannot grow, so that is the hard c
 
 - `getObjectPropertyValue(object, propertyName)`: Gets a property value from a JavaScript object
 - `allocateJSstring(string)`: Creates a JavaScript string in the QuickJS environment
-- `freeValue(handle)`: Releases an object handle returned by the sandbox (converted values are released automatically)
+- `freeValue(handle)`: Optionally releases an object handle early. Converted values are released automatically and handles are reclaimed when the instance is dropped, so this is only for runs that produce very many handles
 
 ### Host Function Integration
 
@@ -244,14 +244,18 @@ The wasm linear memory is a fixed ~16.5MB and cannot grow, so that is the hard c
 
 Return values from the sandbox are converted to host values: integers, floats, booleans, strings (UTF-8 safe), `null` and `undefined` map to their host equivalents; objects (including promises and module handles) are returned as opaque `bigint` handles for use with `getObjectPropertyValue`/`getPromiseResult`/`callModFunction`.
 
-Converted values are released automatically. Handles are not — they are yours until you call `freeValue(handle)`, since only you know when you have finished reading from one. For the one-script-per-instance model you can ignore this entirely; it matters when a single run produces many handles:
+Converted values are released automatically. Object handles are not, since only you know when you have finished reading from one — but releasing them is **optional**, and for the one-script-per-instance model you can ignore `freeValue` entirely. It earns its keep only when a single run produces very many handles, which would otherwise fill the instance's heap before the run is done:
 
 ```javascript
 const quickjs = await createQuickJS();
-const handle = quickjs.evalSource("({ answer: 42 });");
-const answer = quickjs.getObjectPropertyValue(handle, "answer");
-if (answer !== 42) throw new Error("Expected 42, got " + answer);
-quickjs.freeValue(handle);
+
+// freeValue is only worth calling when one run produces handles in bulk
+for (let n = 0; n < 1000; n++) {
+  const handle = quickjs.evalSource(`({ value: ${n} });`);
+  const value = quickjs.getObjectPropertyValue(handle, "value");
+  if (value !== n) throw new Error("Expected " + n + ", got " + value);
+  quickjs.freeValue(handle);
+}
 ```
 
 A failed compile throws rather than returning empty bytecode, so a source too large to compile is reported at `compileToByteCode` instead of surfacing later as a call on a broken module.

--- a/quickjslib/README.md
+++ b/quickjslib/README.md
@@ -23,7 +23,13 @@ npm install quickjs-wasm
 
 This library is built for **short-lived, single-use JavaScript environments**: create an instance, run one untrusted script, throw the instance away.
 
-**You are never required to release anything.** Dropping the instance reclaims all of it, and there is no disposal API you have to remember. Values converted to host values — numbers, booleans, strings, `null` — are released as they cross the boundary, along with the buffers and C strings each call allocates, so an instance can serve many evaluations without growing. Object handles are the one thing the library cannot release for you, because only you know when you have finished reading from one; they stay alive until the instance is dropped. `freeValue(handle)` exists for the rare run that produces handles in the hundreds of thousands, which would otherwise exhaust the instance's own heap before it finishes — it is an escape hatch, not an obligation.
+There is deliberately no disposal API. Nothing has to be released and nothing has to be tracked: create an instance, run a script, drop it. The bindings free what they allocate as each call returns — sources, bytecode buffers, and the strings copied out to the host — so a single run can evaluate and compile as much as it likes without growing. Whatever is still held when you drop the instance goes with it.
+
+### What counts as a leak
+
+Some values are retained for the life of an instance: an object handle you were given, the function object behind a module call, the exception path in the pending-job loop. All of them are bounded per instance and reclaimed when it is dropped. **This library does not treat those as bugs.** A retention that can only be observed by keeping one instance alive across many scripts is out of scope, because that is precisely the mode this library tells you not to use it in.
+
+What *is* in scope is anything that scales with the work a single script does — sources, bytecode, strings crossing the boundary. Those are freed at the call boundary, because the wasm heap is a fixed ~16.5MB and is only reclaimed after the run finishes, so a run that leaks competes with itself.
 
 Creating a fresh instance per execution is also the stronger isolation property: no state carries over between untrusted scripts — no polluted prototypes, no globals stashed by a previous run, nothing observable from one script to the next.
 
@@ -234,7 +240,8 @@ The wasm linear memory is a fixed ~16.5MB and cannot grow, so that is the hard c
 
 - `getObjectPropertyValue(object, propertyName)`: Gets a property value from a JavaScript object
 - `allocateJSstring(string)`: Creates a JavaScript string in the QuickJS environment
-- `freeValue(handle)`: Optionally releases an object handle early. Converted values are released automatically and handles are reclaimed when the instance is dropped, so this is only for runs that produce very many handles
+
+<sup>There is one escape hatch, which one-shot users never need: `freeValue(handle)` releases an object handle early. It exists only for a single run that produces handles in the hundreds of thousands, where they would otherwise fill the instance's heap before the run finishes. If you are wondering whether you should be calling it, you should not.</sup>
 
 ### Host Function Integration
 
@@ -244,21 +251,9 @@ The wasm linear memory is a fixed ~16.5MB and cannot grow, so that is the hard c
 
 Return values from the sandbox are converted to host values: integers, floats, booleans, strings (UTF-8 safe), `null` and `undefined` map to their host equivalents; objects (including promises and module handles) are returned as opaque `bigint` handles for use with `getObjectPropertyValue`/`getPromiseResult`/`callModFunction`.
 
-Converted values are released automatically. Object handles are not, since only you know when you have finished reading from one — but releasing them is **optional**, and for the one-script-per-instance model you can ignore `freeValue` entirely. It earns its keep only when a single run produces very many handles, which would otherwise fill the instance's heap before the run is done:
+Converted values are released as they cross the boundary; handles are reclaimed when the instance is dropped. Neither requires anything from you.
 
-```javascript
-const quickjs = await createQuickJS();
-
-// freeValue is only worth calling when one run produces handles in bulk
-for (let n = 0; n < 1000; n++) {
-  const handle = quickjs.evalSource(`({ value: ${n} });`);
-  const value = quickjs.getObjectPropertyValue(handle, "value");
-  if (value !== n) throw new Error("Expected " + n + ", got " + value);
-  quickjs.freeValue(handle);
-}
-```
-
-A failed compile throws rather than returning empty bytecode, so a source too large to compile is reported at `compileToByteCode` instead of surfacing later as a call on a broken module.
+A failed compile throws rather than returning empty bytecode, so a source too large or too broken to compile is reported at `compileToByteCode` instead of surfacing later as a call on a broken module.
 
 ## Building from source
 

--- a/quickjslib/README.md
+++ b/quickjslib/README.md
@@ -216,6 +216,9 @@ The wasm linear memory is a fixed ~16.5MB and cannot grow, so that is the hard c
 
 ## API Reference
 
+TypeScript declarations ship with the package, so the distinction that matters most is visible at the call site: converted values (`number | string | boolean | null | undefined`) versus `JSHandle`, the opaque `bigint` reference to something still living inside the sandbox.
+
+
 ### Core Functions
 
 - `createQuickJS()`: Creates a new QuickJS instance

--- a/quickjslib/js/quickjs.d.ts
+++ b/quickjslib/js/quickjs.d.ts
@@ -1,0 +1,144 @@
+/**
+ * An opaque reference to a value inside the sandbox. Objects, arrays,
+ * promises and module namespaces cross the boundary as handles rather than
+ * being converted, because converting them would mean copying an arbitrary
+ * object graph. Read from one with `getObjectPropertyValue`, resolve one with
+ * `getPromiseResult`, call into one with `callModFunction`.
+ *
+ * Handles are reclaimed when the instance is dropped. There is nothing to
+ * release by hand.
+ */
+export type JSHandle = bigint;
+
+/**
+ * What a value from the sandbox becomes on the host. Numbers, strings,
+ * booleans, `null` and `undefined` are converted; everything else arrives as
+ * a {@link JSHandle}.
+ */
+export type JSValue = number | string | boolean | JSHandle | null | undefined;
+
+/**
+ * A function the guest can call with `env.callHostAsync({ function_name, ... })`.
+ *
+ * The whole argument object arrives as a handle — read arguments from it with
+ * `getObjectPropertyValue`. The return value must be a handle to a value
+ * inside the sandbox, which is what `allocateJSstring` produces.
+ */
+export type HostFunction = (params: JSHandle) => JSHandle | Promise<JSHandle>;
+
+/**
+ * The raw wasm exports.
+ *
+ * @internal Reaching into these is not part of the supported API and they can
+ * change with any release. They are declared only because arming an eval
+ * deadline around a guest resumed by an async host function currently has no
+ * first-class equivalent.
+ */
+export interface QuickJSWasmExports {
+  memory: WebAssembly.Memory;
+  set_eval_deadline(deadlineMs: number): void;
+  request_interrupt(): void;
+  clear_interrupt(): void;
+  set_memory_limit(bytes: number): void;
+  [name: string]: unknown;
+}
+
+export interface QuickJS {
+  /**
+   * Functions the guest may call through `env.callHostAsync`, keyed by the
+   * `function_name` the guest passes.
+   */
+  hostFunctions: Record<string, HostFunction>;
+
+  /** @internal see {@link QuickJSWasmExports} */
+  wasmInstance: QuickJSWasmExports;
+
+  /**
+   * Evaluates JavaScript and returns the value of its last expression.
+   *
+   * @param modulefilename pass a filename to evaluate as a module
+   * @param timeoutMs wall-clock budget; the guest is interrupted past it,
+   * so `while(true){}` cannot hang the host. 0 means no deadline.
+   * @throws if the guest throws, is interrupted, or runs out of memory
+   */
+  evalSource(src: string, modulefilename?: string, timeoutMs?: number): JSValue;
+
+  /**
+   * Compiles to QuickJS bytecode, for evaluating repeatedly or storing.
+   *
+   * @throws if the source cannot be compiled, including when it is too large
+   * to compile within the instance's heap
+   */
+  compileToByteCode(src: string, modulefilename?: string): Uint8Array;
+
+  /** Evaluates bytecode from {@link QuickJS.compileToByteCode}. */
+  evalByteCode(bytecode: Uint8Array, timeoutMs?: number): JSValue;
+
+  /**
+   * Loads a compiled module and returns a handle to its namespace.
+   *
+   * @throws if the bytecode is empty
+   */
+  loadByteCode(bytecode: Uint8Array): JSHandle;
+
+  /**
+   * Calls an exported function of a loaded module. Arguments are not
+   * currently supported.
+   */
+  callModFunction(
+    mod: JSHandle,
+    functionname: string,
+    timeoutMs?: number,
+  ): JSValue;
+
+  /** Reads a property from an object handle. */
+  getObjectPropertyValue(jsval: JSHandle, propertyname: string): JSValue;
+
+  /**
+   * Reads the result of a settled promise handle. Await
+   * {@link QuickJS.waitForPendingAsyncInvocations} first if the guest awaited
+   * a host function.
+   */
+  getPromiseResult(jsval: JSHandle): JSValue;
+
+  /**
+   * Drains host functions the guest is awaiting, including any scheduled
+   * while draining. Guest `await` suspends inside QuickJS, so the guest only
+   * continues once these settle.
+   */
+  waitForPendingAsyncInvocations(): Promise<void>;
+
+  /** Creates a string inside the sandbox — how a host function returns one. */
+  allocateJSstring(str: string): JSHandle;
+
+  /**
+   * Caps what the QuickJS runtime may allocate. Exceeding it raises a
+   * catchable out-of-memory exception inside the sandbox and leaves the
+   * instance usable. The wasm heap is a fixed ~16.5MB, so keep the limit
+   * below that for it to bind.
+   */
+  setMemoryLimit(bytes: number): void;
+
+  /**
+   * Asks for the guest to be interrupted at its next interrupt check —
+   * for cancelling from a host function a guest that is about to resume.
+   */
+  requestInterrupt(): void;
+
+  /**
+   * Releases an object handle early.
+   *
+   * You almost certainly do not need this: handles are reclaimed when the
+   * instance is dropped, and this library is built for one script per
+   * instance. It exists for a single run that produces handles in the
+   * hundreds of thousands, which would otherwise fill the instance's heap
+   * before the run finishes.
+   */
+  freeValue(handle: JSHandle): void;
+}
+
+/**
+ * Creates a sandbox. Intended to be used for one untrusted script and then
+ * dropped — see "Intended use: one sandbox per execution" in the README.
+ */
+export declare function createQuickJS(): Promise<QuickJS>;

--- a/quickjslib/js/types.test.js
+++ b/quickjslib/js/types.test.js
@@ -1,0 +1,62 @@
+import { test } from "node:test";
+import { ok, deepEqual } from "node:assert";
+import { readFileSync } from "fs";
+import { createQuickJS } from "./quickjs.js";
+
+/**
+ * Keeps quickjs.d.ts honest without pulling in a TypeScript toolchain: every
+ * member it declares has to exist on a real instance, and every member of the
+ * documented API has to be declared. Signatures are not checked - this catches
+ * drift in the surface, which is what silently rots.
+ */
+const declarations = readFileSync(
+  new URL("./quickjs.d.ts", import.meta.url),
+  "utf-8",
+);
+
+function declaredMembers() {
+  const body = declarations.slice(
+    declarations.indexOf("export interface QuickJS {"),
+    declarations.lastIndexOf("}"),
+  );
+  return new Set([...body.matchAll(/^  (\w+)[(:<]/gm)].map(([, name]) => name));
+}
+
+// The surface the README documents, which is what consumers are told to use.
+const DOCUMENTED_API = [
+  "hostFunctions",
+  "evalSource",
+  "compileToByteCode",
+  "evalByteCode",
+  "loadByteCode",
+  "callModFunction",
+  "getObjectPropertyValue",
+  "getPromiseResult",
+  "waitForPendingAsyncInvocations",
+  "allocateJSstring",
+  "setMemoryLimit",
+  "requestInterrupt",
+  "freeValue",
+];
+
+test("every declared member exists on an instance", async () => {
+  const quickjs = await createQuickJS();
+  for (const name of declaredMembers()) {
+    ok(
+      quickjs[name] !== undefined,
+      `quickjs.d.ts declares ${name}, which does not exist on the instance`,
+    );
+  }
+});
+
+test("the documented API is fully declared", async () => {
+  const declared = declaredMembers();
+  const missing = DOCUMENTED_API.filter((name) => !declared.has(name));
+  deepEqual(missing, [], "documented members missing from quickjs.d.ts");
+});
+
+test("the documented API exists on an instance", async () => {
+  const quickjs = await createQuickJS();
+  const missing = DOCUMENTED_API.filter((name) => quickjs[name] === undefined);
+  deepEqual(missing, [], "documented members missing from the implementation");
+});

--- a/quickjslib/package.json
+++ b/quickjslib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "quickjs-wasm",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "Execute javascript in a secure WebAssembly sandbox",
   "main": "js/quickjs.js",
   "types": "js/quickjs.d.ts",

--- a/quickjslib/package.json
+++ b/quickjslib/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.4",
   "description": "Execute javascript in a secure WebAssembly sandbox",
   "main": "js/quickjs.js",
+  "types": "js/quickjs.d.ts",
   "type": "module",
   "scripts": {
     "test": "node --test 'js/*.test.js'"
@@ -19,6 +20,7 @@
   "homepage": "https://github.com/petersalomonsen/quickjs-rust-near#readme",
   "files": [
     "js/quickjs.js",
+    "js/quickjs.d.ts",
     "js/wasi.js",
     "jseval.wasm",
     "CHANGELOG.md"

--- a/quickjslib/package.json
+++ b/quickjslib/package.json
@@ -20,6 +20,7 @@
   "files": [
     "js/quickjs.js",
     "js/wasi.js",
-    "jseval.wasm"
+    "jseval.wasm",
+    "CHANGELOG.md"
   ]
 }


### PR DESCRIPTION
Acts on the 0.0.4 integration review, plus TypeScript declarations. All four of the review's factual claims check out — each verified before changing anything. **No behaviour changes; types and documentation only.**

## 1. `freeValue` read as an obligation

The lifetime section had drifted into describing handle management as part of the model — offering explicit lifetime management one paragraph before telling readers to use quickjs-emscripten if they want explicit lifetime management — and the example called `freeValue` on a single trivial handle, teaching cleanup as the normal pattern.

Restores **"There is deliberately no disposal API"** as the claim and demotes `freeValue` to a one-line footnote ending "if you are wondering whether you should be calling it, you should not." Kept rather than removed: it closes a real hole (handles previously could not be released *at all*) at zero cost to one-shot users, and can no longer be read as part of the flow.

## 2. Leak-chasing needs a stopping point

The review is right that this does not converge, and the audit is worse than the `fun_obj` case it names:

| site | retained |
| --- | --- |
| `js_call_function` | `fun_obj` from `JS_GetPropertyStr` |
| `js_load_bytecode` | the `JS_LoadModule` promise and the module-name atom |
| `js_std_loop_no_os` | the exception and its `JS_ToCString` copy |
| `promise_callback` | the `JS_Call` result |

All bounded per instance, none observable under one-shot use, none noticed across four releases. So the README now states the rule instead of fixing them one release at a time: **retention only observable by keeping an instance alive across many scripts is not a bug**, while anything scaling with a single run's work is — the heap is a fixed ~16.5MB reclaimed only after the run ends, so a run that leaks competes with itself. That is also the line the already-shipped fixes fall on, and it makes `fun_obj` a non-issue rather than the next PR.

## 3 & 4. Release notes

Adds `CHANGELOG.md`, shipped in the package, which flags the 0.0.4 `compileToByteCode`/`loadByteCode` change from return value to exception as a **behaviour change** that warranted a minor bump, and **corrects the motivating consumer**: #65 cited WebAssembly Music, but its song source is passed in as a string and compiled *inside the guest*, so `compileToByteCode` only ever sees the fixed-size guest bundle. The real caller is `examples/aiproxy/web/openai/sandbox.js`, which interpolates untrusted script text straight into it with no `try`/`catch`.

## TypeScript declarations

The distinction that matters most here was invisible in JS: a converted value versus a handle to something still inside the sandbox. `evalSource` now returns `number | string | boolean | JSHandle | null | undefined`, with `JSHandle` a documented alias rather than a bare `bigint`.

Hand-written rather than generated — the package's CI runs `node --test` with zero installs, and a TypeScript build step costs more than a 150-line file is worth. `types.test.js` keeps them honest instead: every declared member must exist on a real instance, and every README-documented member must be declared. Confirmed non-vacuous by adding a bogus member and watching it fail; separately validated against `tsc --strict` with realistic usage, which type-checks.

`freeValue` carries its demoted framing into the types so autocomplete does not re-promote it. `wasmInstance` is declared `@internal`: javascriptmusic reaches into `set_eval_deadline`/`clear_interrupt` to re-arm a deadline across an async host call, because there is no first-class API for that — worth two small public methods before long, left out of a docs release.

31/31 tests pass. Version bumped to 0.0.5, since 0.0.4 is already published.

🤖 Generated with [Claude Code](https://claude.com/claude-code)