### PR TITLE
Fail the transaction when submitted JavaScript does not compile

### DIFF
--- a/src/jslib.rs
+++ b/src/jslib.rs
@@ -361,6 +361,13 @@ pub fn compile_js(script: String, modulename: Option<String>) -> Vec<u8> {
             out_buf_len_ptr as i32,
             is_module,
         );
+        // JS_WriteObject returns NULL when the source did not compile. Without
+        // this the caller stores empty bytecode on chain and the failure only
+        // surfaces when someone later runs it - and the from_raw_parts below
+        // is undefined behaviour for a null pointer even at length zero.
+        if result_ptr == 0 || out_buf_len == 0 {
+            env::panic_str("Failed to compile JavaScript");
+        }
         result = slice::from_raw_parts(result_ptr as *mut u8, out_buf_len).to_vec();
     }
     return result;


### PR DESCRIPTION
Found while checking whether any of the recent `quickjs-wasm` work applies to the Rust contract side. Most of it does not — the contract links `libjseval.a`, not the JS bindings or `wasmlib.c`, and one-shot instances plus gas metering make the interrupt handler, memory limit and the freeing work irrelevant on chain. This one does apply, and it is worse here.

## The bug

`js_compile_to_bytecode` returns NULL when the source does not compile. `compile_js` did not check, so:

```rust
result = slice::from_raw_parts(result_ptr as *mut u8, out_buf_len).to_vec();  // null, 0
```

- **`submit_script` ([lib.rs:43](src/lib.rs#L43)) and `post_javascript` ([examples/nft/src/lib.rs:345](examples/nft/src/lib.rs#L345)) store empty bytecode on chain and the transaction succeeds.** Gas is spent, state is committed, and the failure appears later when someone runs the script — pointing at the run rather than the broken submission.
- **`slice::from_raw_parts` on a null pointer is undefined behaviour even at length zero.** The debug precondition check catches it in tests; it is compiled out of the release builds that get deployed.

Reproduced by compiling `function ( { syntax error` through `compile_js`:

```
unsafe precondition(s) violated: slice::from_raw_parts requires the pointer to be
aligned and non-null ... thread caused non-unwinding panic. aborting.
```

## The fix

Panic with `Failed to compile JavaScript` before constructing the slice, so the transaction reverts and the caller is told which step failed. Verified the same input now produces `env_panic: Failed to compile JavaScript`, and the existing 18 unit tests still pass.

This is the same failure shape as the host-side fix in quickjs-wasm 0.0.4, which is what prompted looking here.

## Not covered

The panic message does not include the QuickJS exception (`SyntaxError: expecting ';'` and friends). `js_compile_to_bytecode` prints it with `printf`, which goes nowhere useful on chain. Surfacing it needs a way to read the pending exception from C — worth doing, but it is a bigger change to a file the contract and the npm package share, so it is not in here.

Unit tests cannot assert a panic in this harness (panics abort the wasm test binary), so this has no regression test; an e2e test around `submit_script` would be the place for one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)